### PR TITLE
fix: prevent Windows EADDRINUSE and allow configurable bridge port

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ Visualize your entire project architecture with `visualizer.map` (`map_project` 
 | `GOPEAK_TOOL_PROFILE` | Tool exposure profile: `compact`, `full`, `legacy` | `compact` |
 | `MCP_TOOL_PROFILE` | Fallback profile env alias | `compact` |
 | `GODOT_PATH` | Explicit Godot executable path | auto-detect |
+| `GODOT_BRIDGE_PORT` | Bridge/Visualizer HTTP+WS port override (aliases: `MCP_BRIDGE_PORT`, `GOPEAK_BRIDGE_PORT`) | `6505` |
 | `DEBUG` | Enable server debug logs (`true`/`false`) | `false` |
 | `LOG_MODE` | Recording mode: `lite` or `full` | `lite` |
 | `GOPEAK_TOOLS_PAGE_SIZE` | Number of tools per `tools/list` page (pagination) | `20` |
@@ -244,16 +245,16 @@ Visualize your entire project architecture with `visualizer.map` (`map_project` 
 
 | Port | Service |
 |---|---|
-| `6505` | Unified Godot Bridge + Visualizer server (+ `/health`, `/mcp`) |
+| `6505` (default) | Unified Godot Bridge + Visualizer server (+ `/health`, `/mcp`) |
 | `6005` | Godot LSP |
 | `6006` | Godot DAP |
 | `7777` | Runtime addon command socket (only needed for runtime tools) |
 
 ### Minimal port profiles
 
-- **Core editing only**: `6505`
-- **Core + runtime actions (screenshots/input/runtime inspect)**: `6505` + `7777`
-- **Full debugging + diagnostics**: `6505` + `6005` + `6006` + `7777`
+- **Core editing only**: bridge port (`GODOT_BRIDGE_PORT`, default `6505`)
+- **Core + runtime actions (screenshots/input/runtime inspect)**: bridge port + `7777`
+- **Full debugging + diagnostics**: bridge port + `6005` + `6006` + `7777`
 
 ---
 

--- a/src/addon/godot_mcp_editor/mcp_client.gd
+++ b/src/addon/godot_mcp_editor/mcp_client.gd
@@ -60,11 +60,28 @@ func _process(_delta: float) -> void:
 				_handle_disconnect()
 
 
-func connect_to_server(url: String = DEFAULT_URL) -> void:
-	server_url = url
+func connect_to_server(url: String = "") -> void:
+	server_url = _resolve_server_url(url)
 	_should_reconnect = true
 	_current_reconnect_delay = RECONNECT_DELAY
 	_attempt_connection()
+
+
+func _resolve_server_url(explicit_url: String) -> String:
+	if explicit_url != "":
+		return explicit_url
+
+	var env_keys := ["GODOT_BRIDGE_PORT", "MCP_BRIDGE_PORT", "GOPEAK_BRIDGE_PORT"]
+	for key in env_keys:
+		var raw := OS.get_environment(key)
+		if raw == "":
+			continue
+		if raw.is_valid_int():
+			var port := int(raw)
+			if port >= 1 and port <= 65535:
+				return "ws://127.0.0.1:%d/godot" % port
+
+	return DEFAULT_URL
 
 
 func disconnect_from_server() -> void:

--- a/src/visualizer-server.ts
+++ b/src/visualizer-server.ts
@@ -112,7 +112,7 @@ export async function serveVisualization(projectData: unknown, bridge: GodotBrid
   bridge.on('godot_connected', onGodotConnected);
   bridge.on('godot_disconnected', onGodotDisconnected);
 
-  const url = 'http://localhost:6505';
+  const url = `http://localhost:${bridge.getStatus().port}`;
   console.error(`[visualizer] Serving at ${url}`);
   openBrowser(url);
   return url;

--- a/test-bridge.mjs
+++ b/test-bridge.mjs
@@ -8,8 +8,13 @@ import { WebSocket } from 'ws';
 import { setTimeout as delay } from 'node:timers/promises';
 
 const MCP_SERVER = './build/index.js';
-const GODOT_WS_URL = 'ws://127.0.0.1:6505/godot';
-const VIZ_WS_URL = 'ws://127.0.0.1:6505/visualizer';
+const bridgePortRaw = process.env.GODOT_BRIDGE_PORT || process.env.MCP_BRIDGE_PORT || process.env.GOPEAK_BRIDGE_PORT;
+const parsedBridgePort = Number.parseInt(bridgePortRaw || '', 10);
+const BRIDGE_PORT = Number.isInteger(parsedBridgePort) && parsedBridgePort >= 1 && parsedBridgePort <= 65535
+  ? parsedBridgePort
+  : 6505;
+const GODOT_WS_URL = `ws://127.0.0.1:${BRIDGE_PORT}/godot`;
+const VIZ_WS_URL = `ws://127.0.0.1:${BRIDGE_PORT}/visualizer`;
 const GODOT_PATH = process.env.GODOT_PATH || '/home/doyun/Apps/godot-4.6-rc2/Godot_v4.6-rc2_linux.x86_64';
 
 let passed = 0;
@@ -46,7 +51,7 @@ async function main() {
   // 1. Start MCP server
   console.log('📦 Starting MCP server...');
   const server = spawn('node', [MCP_SERVER], {
-    env: { ...process.env, GODOT_PATH, DEBUG: 'true' },
+    env: { ...process.env, GODOT_PATH, DEBUG: 'true', GODOT_BRIDGE_PORT: String(BRIDGE_PORT) },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 


### PR DESCRIPTION
## Summary
This PR fixes issue #2 where Windows stdio MCP sessions could leave orphaned server processes and hit `EADDRINUSE` on the hardcoded bridge port.

### Changes
- add robust shutdown handling in `src/index.ts`:
  - `SIGINT`, `SIGTERM`, `SIGHUP`, `beforeExit`, `exit`
  - single-guarded shutdown path to avoid duplicate cleanup
- make bridge port configurable in `src/godot-bridge.ts`:
  - `GODOT_BRIDGE_PORT`
  - aliases: `MCP_BRIDGE_PORT`, `GOPEAK_BRIDGE_PORT`
  - validates range `1..65535`
- await async server close in bridge `stop()` to release sockets cleanly
- remove hardcoded `6505` assumptions:
  - `src/visualizer-server.ts` now uses dynamic bridge port
  - `src/addon/godot_mcp_editor/mcp_client.gd` resolves env port overrides
  - `test-bridge.mjs` uses same env-based port resolution
- document env var in `README.md`

## Verification
- `npm run build` ✅
- local SIGTERM restart/rebind smoke test on custom port (`6515`) ✅
- env alias smoke (`GOPEAK_BRIDGE_PORT=6516`) ✅

Fixes #2
