### PR TITLE
feat: MCP platform foundation (prompts, CI, release automation, architecture docs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Typecheck
+        run: npx tsc --noEmit
+
+      - name: Smoke / integration test
+        env:
+          GODOT_PATH: /bin/true
+          GOPEAK_BRIDGE_HOST: 127.0.0.1
+          GOPEAK_BRIDGE_PORT: 6505
+        run: npm run test:ci

--- a/README.md
+++ b/README.md
@@ -154,6 +154,35 @@ GoPeak also exposes two CLI bin names:
 
 ---
 
+## CI
+
+GitHub Actions runs on push/PR and executes:
+
+1. `npm run build`
+2. `npx tsc --noEmit`
+3. `npm run test:ci`
+
+Run the same checks locally:
+
+```bash
+npm run ci
+```
+
+---
+
+## Versioning & Release
+
+Use the built-in bump script to keep `package.json` and `server.json` in sync:
+
+```bash
+node scripts/bump-version.mjs patch
+node scripts/bump-version.mjs minor --dry-run
+```
+
+Full release checklist: [`docs/release-process.md`](docs/release-process.md).
+
+---
+
 ## Addons (Recommended)
 
 ### Auto Reload + Editor Bridge + Runtime Addon installer
@@ -272,6 +301,8 @@ Visualize your entire project architecture with `visualizer.map` (`map_project` 
 
 ## Docs & Project Links
 
+- [Architecture (MCP Platform Direction)](docs/architecture.md)
+- [Platform Roadmap (P1/P2/P3)](docs/platform-roadmap.md)
 - [CHANGELOG](CHANGELOG.md)
 - [ROADMAP](ROADMAP.md)
 - [CONTRIBUTING](CONTRIBUTING.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,158 @@
+# GoPeak MCP Platform Architecture
+
+> Scope: repository-specific architecture for evolving `godot-mcp` from a tool-centric server into a balanced MCP platform (tools + resources + prompts), with explicit transport boundaries and verification discipline.
+
+## Why this document
+
+The current codebase already has strong tool coverage and an initial resources layer:
+
+- Server bootstrap and request handling: `src/index.ts`
+- Tool definitions/dispatch: `src/tools.ts` (+ LSP/DAP helpers)
+- Resource handlers: `src/resources.ts`
+- Godot bridge (HTTP + WS for editor/runtime integration): `src/godot-bridge.ts`
+- Current MCP package transport declaration: `server.json` (`stdio`)
+
+The next step is to make this architecture explicit and prepare a safe path for platform growth.
+
+---
+
+## Current State (as implemented)
+
+```mermaid
+flowchart LR
+    Client[MCP Client\nClaude/Cursor/Cline] -->|MCP stdio| Server[src/index.ts\nGoPeak Server]
+
+    Server --> Tools[Tool handlers\nsrc/tools.ts + lsp_client.ts + dap_client.ts]
+    Server --> Resources[Resource handlers\nsrc/resources.ts]
+    Server --> Bridge[Godot Bridge\nsrc/godot-bridge.ts\nHTTP+WS :6505]
+
+    Bridge --> Addon[Godot Editor/Runtime Addons\nsrc/addon/...]
+    Server --> Godot[Godot process\nrun/editor/lsp/dap sockets]
+
+    note1[Prompts capability is not yet exposed\nin MCP capabilities]:::note
+    Server -. gap .-> note1
+
+    classDef note fill:#fff3cd,stroke:#f0ad4e,color:#333;
+```
+
+### Current architecture facts
+
+1. **MCP transport is stdio-first** for client/server communication (`server.json`, `StdioServerTransport` in `src/index.ts`).
+2. **Bridge transport is separate and internal**: the Godot bridge exposes HTTP/WS endpoints for addon/runtime integration (`src/godot-bridge.ts`).
+3. **Tools are mature** and broad (project/scene/script/runtime/LSP/DAP/visualizer families).
+4. **Resources exist but are narrow** (`godot://project/info`, `godot://scene/{path}`, `godot://script/{path}`, `godot://resource/{path}`).
+5. **Prompts are not yet first-class MCP capability** in server capability declaration.
+
+---
+
+## Target State (platform direction)
+
+```mermaid
+flowchart LR
+    Client[MCP Client] -->|Transport adapter| MCPGateway[MCP Entry Layer]
+
+    MCPGateway --> ToolsAPI[Tools Capability]
+    MCPGateway --> ResourcesAPI[Resources Capability]
+    MCPGateway --> PromptsAPI[Prompts Capability]
+
+    ToolsAPI --> AppCore[Domain Services / App Core]
+    ResourcesAPI --> AppCore
+    PromptsAPI --> PromptPack[Prompt registry + templates]
+    PromptPack --> AppCore
+
+    AppCore --> Bridge[Godot Bridge Layer\nHTTP+WS integration]
+    AppCore --> Engine[Godot process + LSP + DAP]
+
+    subgraph Transports
+      Stdio[stdio adapter]
+      HTTPStream[future streamable HTTP adapter]
+    end
+
+    Stdio --> MCPGateway
+    HTTPStream --> MCPGateway
+```
+
+### Target principles
+
+- **Capability parity**: platform supports tools, resources, and prompts as peer capabilities.
+- **Transport isolation**: MCP transport adapters are cleanly separated from app/core logic.
+- **Deterministic contracts**: tools/resources/prompts have versioned schemas and behavior tests.
+- **Backward-safe evolution**: compact/full tool profiles and existing aliases continue to work.
+
+---
+
+## Module boundaries (proposed)
+
+These boundaries map to existing files and planned additions; they are design boundaries first, not a forced immediate refactor.
+
+### 1) MCP entry layer
+
+- **Today**: mostly in `src/index.ts`
+- **Responsibility**:
+  - server construction + capability registration
+  - transport wiring (stdio now; additional adapters later)
+  - request routing to capability handlers
+- **Rule**: no direct Godot business logic in transport handlers.
+
+### 2) Capability modules
+
+- **Tools module**: existing `src/tools.ts`, `src/lsp_client.ts`, `src/dap_client.ts`
+- **Resources module**: existing `src/resources.ts`
+- **Prompts module (new)**: prompt templates + parameterized prompt endpoints
+- **Rule**: each capability owns its schema definitions and validation.
+
+### 3) Domain services / app core
+
+- **Today**: spread across `src/index.ts`, `src/project_utils.ts`, `src/gdscript_utils.ts`, parser/util modules
+- **Responsibility**:
+  - project path lifecycle
+  - process orchestration
+  - file operation policy
+  - reusable operation primitives consumed by tools/resources/prompts
+- **Rule**: no transport-specific types in core logic.
+
+### 4) Integration layer
+
+- **Bridge**: `src/godot-bridge.ts` + addons in `src/addon/...`
+- **Engine protocols**: LSP/DAP clients and Godot process interactions
+- **Rule**: integration errors map to stable MCP error surfaces.
+
+---
+
+## Transport split contract
+
+To avoid coupling regressions, define an explicit split:
+
+- **MCP Client Transport**: how external clients talk to GoPeak (currently stdio; future HTTP option).
+- **Godot Integration Transport**: how GoPeak talks to Godot/editor runtime (bridge HTTP+WS, LSP, DAP, runtime socket).
+
+These two transport domains should evolve independently.
+
+---
+
+## Verification discipline (required for platform changes)
+
+For any change that touches MCP capabilities or transport:
+
+1. **Capability registration checks**
+   - Verify declared capabilities match implemented handlers (tools/resources/prompts).
+2. **Schema checks**
+   - Validate input/output schema compatibility for new/changed tools/resources/prompts.
+3. **Transport checks**
+   - Confirm stdio flow remains functional (`npx -y gopeak`, inspector/manual smoke).
+   - For bridge-related changes, verify `/health`, websocket connection, and at least one tool round-trip.
+4. **Regression checks**
+   - Keep compact profile discoverability (`tool.catalog`) working.
+   - Confirm legacy aliases still resolve.
+5. **Release artifact checks**
+   - `npm run build` success and package metadata consistency (`package.json`, `server.json`).
+
+---
+
+## Non-goals for this architecture step
+
+- No forced large refactor in one PR.
+- No immediate deprecation of legacy tool names.
+- No transport expansion without compatibility tests.
+
+This document defines the architectural baseline for incremental implementation in `docs/platform-roadmap.md`.

--- a/docs/platform-roadmap.md
+++ b/docs/platform-roadmap.md
@@ -1,0 +1,137 @@
+# GoPeak MCP Platform Roadmap
+
+> Purpose: phased, repository-grounded plan to evolve GoPeak into a full MCP platform with strong tool/resource/prompt support, transport clarity, and verification discipline.
+
+## Baseline (March 2026)
+
+Ground truth from current repository:
+
+- MCP server entrypoint: `src/index.ts`
+- Tool system: mature and broad (`src/tools.ts` and related modules)
+- Resource support: present via `src/resources.ts`
+- Prompts capability: not yet first-class in MCP capability registration
+- MCP transport in package metadata: stdio (`server.json`)
+- Internal bridge transport: HTTP+WS (`src/godot-bridge.ts`)
+
+---
+
+## P1 — Capability Foundation (Tools + Resources + Prompts skeleton)
+
+### Goals
+
+1. Keep existing tool behavior stable.
+2. Harden and document resource behavior.
+3. Introduce prompts capability scaffolding with minimal, high-value prompt templates.
+
+### Candidate deliverables
+
+- Capability registration structure in server entrypoint that cleanly wires:
+  - tools
+  - resources
+  - prompts
+- Initial prompt set (for common workflows such as scene creation/debug loop guidance).
+- Capability-level documentation with examples and compatibility notes.
+
+### Acceptance criteria
+
+- Tools list and execution still function in compact and full profiles.
+- Existing resource URIs keep working (`godot://project/info`, `godot://scene/{path}`, etc.).
+- Prompt endpoints are discoverable and invocable from MCP clients that support prompts.
+- No breaking change to current `npx -y gopeak` startup and basic operations.
+
+### Risks
+
+- Prompt capability differences across MCP clients.
+- Unclear boundary between “tool logic” and “prompt workflow intent.”
+
+### Mitigation
+
+- Keep prompt templates versioned and additive.
+- Maintain fallback guidance in README for clients without prompt support.
+- Add compatibility notes per client behavior.
+
+---
+
+## P2 — Transport & Boundary Hardening
+
+### Goals
+
+1. Make transport boundaries explicit in implementation.
+2. Prepare optional additional MCP transport path without regressing stdio.
+3. Reduce coupling between MCP entry logic and Godot integration details.
+
+### Candidate deliverables
+
+- Refined module boundaries as defined in `docs/architecture.md`.
+- Transport adapter abstraction (stdio first, optional future HTTP/streamable path).
+- Explicit error mapping policy across bridge/LSP/DAP failures.
+
+### Acceptance criteria
+
+- Stdio transport remains default and passes smoke checks.
+- Bridge-dependent features still work (`/health`, websocket handshake, representative tool call).
+- Transport adapter changes do not require touching tool/resource business logic.
+- `server.json` and runtime behavior remain consistent.
+
+### Risks
+
+- Transport abstraction adds accidental complexity.
+- Runtime/bridge failures surface as inconsistent MCP errors.
+
+### Mitigation
+
+- Introduce boundaries incrementally (small PRs).
+- Add contract tests for error shape and status mapping.
+- Keep one canonical error envelope guideline in docs.
+
+---
+
+## P3 — Verification, Compatibility, and Release Discipline
+
+### Goals
+
+1. Make platform evolution safe through repeatable verification.
+2. Protect backward compatibility (aliases, profiles, capability behavior).
+3. Improve release confidence for npm + MCP registry metadata.
+
+### Candidate deliverables
+
+- Verification checklist integrated into contribution/release process.
+- Capability regression matrix (tools/resources/prompts x compact/full x key clients).
+- Pre-release smoke flow (build, run, inspect, representative calls).
+
+### Acceptance criteria
+
+- Every capability-affecting PR includes verification evidence.
+- Backward compatibility checks are run before version bumps.
+- Release artifacts (`build/`, `package.json`, `server.json`) are validated together.
+
+### Risks
+
+- Verification burden slows iteration.
+- CI/local environment drift causes false negatives.
+
+### Mitigation
+
+- Keep smoke suite lean and deterministic.
+- Separate mandatory checks from extended/manual checks.
+- Record known client-specific behavior in one compatibility table.
+
+---
+
+## Sequencing and ownership guidance
+
+- Execute P1 before significant transport work.
+- Start P2 only after P1 capability contracts are stable.
+- Treat P3 as ongoing discipline, with minimum baseline established before major releases.
+
+---
+
+## Definition of Done for platform transition
+
+The transition is considered successful when:
+
+1. GoPeak exposes practical tools + resources + prompts as first-class MCP capabilities.
+2. MCP transport concerns and Godot integration transport concerns are cleanly separated.
+3. Verification evidence is routine, repeatable, and tied to release quality.
+4. Existing users of `gopeak` / `godot-mcp` retain expected workflows without surprise breakage.

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,0 +1,49 @@
+# Release Process
+
+This repository uses a simple bump -> verify -> tag -> publish flow.
+
+## 1) Bump version
+
+Use the version sync script to update `package.json` + `server.json` (and versioned README references, if present):
+
+```bash
+node scripts/bump-version.mjs patch
+# or: node scripts/bump-version.mjs minor
+# or: node scripts/bump-version.mjs 2.3.0
+```
+
+Preview without writing:
+
+```bash
+node scripts/bump-version.mjs patch --dry-run
+```
+
+## 2) Verify locally
+
+Run release checks before tagging:
+
+```bash
+npm run build
+npx tsc --noEmit
+npm run test:ci
+```
+
+## 3) Commit + tag
+
+```bash
+git add package.json server.json README.md
+# plus any release notes/changelog edits
+git commit -m "chore(release): vX.Y.Z"
+git tag vX.Y.Z
+git push origin main --tags
+```
+
+## 4) Publish release
+
+- Publish to npm using existing publish flow (`npm publish` / CI release job if configured).
+- Create a GitHub Release from tag `vX.Y.Z`.
+
+## Notes
+
+- Keep release changes focused (version metadata + release notes only).
+- `server.json` package version must always match `package.json`.

--- a/package.json
+++ b/package.json
@@ -16,10 +16,16 @@
   ],
   "scripts": {
     "build": "tsc && node scripts/build-visualizer.js && node scripts/build.js",
+    "typecheck": "tsc --noEmit",
+    "test:smoke": "node scripts/smoke-test.mjs",
+    "test:integration": "node test-bridge.mjs",
+    "test:ci": "npm run test:smoke",
+    "ci": "npm run build && npm run typecheck && npm run test:ci",
     "prepare": "npm run build",
     "watch": "tsc --watch",
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
-    "pack": "npm pack --dry-run"
+    "pack": "npm pack --dry-run",
+    "version:bump": "node scripts/bump-version.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+
+const ROOT = process.cwd();
+const PACKAGE_JSON_PATH = path.join(ROOT, 'package.json');
+const SERVER_JSON_PATH = path.join(ROOT, 'server.json');
+const README_PATH = path.join(ROOT, 'README.md');
+const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+const usage = `Usage:\n  node scripts/bump-version.mjs <version|major|minor|patch> [--dry-run]\n\nExamples:\n  node scripts/bump-version.mjs patch\n  node scripts/bump-version.mjs 2.3.0 --dry-run`;
+
+function assertVersion(version) {
+  if (!SEMVER_RE.test(version)) {
+    throw new Error(`Invalid semantic version: ${version}`);
+  }
+}
+
+function bumpVersion(currentVersion, bumpType) {
+  const match = currentVersion.match(/^(\d+)\.(\d+)\.(\d+)/);
+  if (!match) {
+    throw new Error(`Current version is not a simple semver (x.y.z): ${currentVersion}`);
+  }
+
+  const [major, minor, patch] = match.slice(1).map(Number);
+  if (bumpType === 'major') return `${major + 1}.0.0`;
+  if (bumpType === 'minor') return `${major}.${minor + 1}.0`;
+  return `${major}.${minor}.${patch + 1}`;
+}
+
+function replaceVersionReferencesInReadme(content, nextVersion) {
+  return content
+    .replace(/(npx\s+-y\s+gopeak@)(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)/g, `$1${nextVersion}`)
+    .replace(/(npm\s+install\s+-g\s+gopeak@)(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)/g, `$1${nextVersion}`)
+    .replace(/(https:\/\/raw\.githubusercontent\.com\/HaD0Yun\/godot-mcp\/v)(\d+\.\d+\.\d+)(\/install-addon\.(?:sh|ps1))/g, `$1${nextVersion}$3`);
+}
+
+async function readJson(filePath) {
+  return JSON.parse(await fs.readFile(filePath, 'utf8'));
+}
+
+async function writeText(filePath, content, dryRun) {
+  if (!dryRun) {
+    await fs.writeFile(filePath, content, 'utf8');
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run') || args.includes('-d');
+  const target = args.find((arg) => !arg.startsWith('-'));
+
+  if (!target) {
+    console.error(usage);
+    process.exit(1);
+  }
+
+  const pkg = await readJson(PACKAGE_JSON_PATH);
+  const currentVersion = pkg.version;
+  let nextVersion;
+
+  if (target === 'major' || target === 'minor' || target === 'patch') {
+    nextVersion = bumpVersion(currentVersion, target);
+  } else {
+    assertVersion(target);
+    nextVersion = target;
+  }
+
+  assertVersion(nextVersion);
+
+  if (nextVersion === currentVersion) {
+    console.log(`No changes needed. Version is already ${nextVersion}.`);
+    return;
+  }
+
+  const changed = [];
+
+  pkg.version = nextVersion;
+  await writeText(PACKAGE_JSON_PATH, `${JSON.stringify(pkg, null, 2)}\n`, dryRun);
+  changed.push('package.json');
+
+  const server = await readJson(SERVER_JSON_PATH);
+  server.version = nextVersion;
+  if (Array.isArray(server.packages)) {
+    for (const entry of server.packages) {
+      if (entry && typeof entry === 'object' && 'version' in entry) {
+        entry.version = nextVersion;
+      }
+    }
+  }
+  await writeText(SERVER_JSON_PATH, `${JSON.stringify(server, null, 2)}\n`, dryRun);
+  changed.push('server.json');
+
+  const readmeOriginal = await fs.readFile(README_PATH, 'utf8');
+  const readmeUpdated = replaceVersionReferencesInReadme(readmeOriginal, nextVersion);
+  if (readmeUpdated !== readmeOriginal) {
+    await writeText(README_PATH, readmeUpdated, dryRun);
+    changed.push('README.md');
+  }
+
+  console.log(`${dryRun ? '[dry-run] ' : ''}Version bump ${currentVersion} -> ${nextVersion}`);
+  console.log(`Updated: ${changed.join(', ')}`);
+  if (dryRun) {
+    console.log('No files were written.');
+  }
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});

--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+import { setTimeout as delay } from 'node:timers/promises';
+import process from 'node:process';
+import { WebSocket } from 'ws';
+
+function parseResponses(data) {
+  return data
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => {
+      try {
+        return JSON.parse(line);
+      } catch {
+        return null;
+      }
+    })
+    .filter(Boolean);
+}
+
+async function reservePort() {
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to reserve a TCP port.')));
+        return;
+      }
+
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+  });
+}
+
+async function connectWebSocket(url) {
+  return await new Promise((resolve, reject) => {
+    const ws = new WebSocket(url);
+    const timer = setTimeout(() => {
+      ws.terminate();
+      reject(new Error(`timeout connecting to ${url}`));
+    }, 3000);
+
+    ws.once('open', () => {
+      clearTimeout(timer);
+      ws.close();
+      resolve();
+    });
+    ws.once('error', (error) => {
+      clearTimeout(timer);
+      reject(error);
+    });
+  });
+}
+
+async function main() {
+  const host = process.env.GOPEAK_BRIDGE_HOST || '127.0.0.1';
+  const configuredPort = Number.parseInt(process.env.GOPEAK_BRIDGE_PORT || '', 10);
+  const port = Number.isInteger(configuredPort) && configuredPort > 0
+    ? configuredPort
+    : await reservePort();
+
+  const server = spawn(process.execPath, ['build/index.js'], {
+    stdio: ['pipe', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      GODOT_PATH: process.env.GODOT_PATH || process.execPath,
+      GOPEAK_BRIDGE_PORT: String(port),
+      GOPEAK_BRIDGE_HOST: host,
+      GOPEAK_TOOL_PROFILE: 'compact',
+    },
+  });
+
+  let stdout = '';
+  let stderr = '';
+  server.stdout.on('data', (chunk) => {
+    stdout += chunk.toString();
+  });
+  server.stderr.on('data', (chunk) => {
+    stderr += chunk.toString();
+  });
+
+  const cleanup = async () => {
+    if (server.exitCode === null) {
+      server.stdin.end();
+      server.kill('SIGTERM');
+      await delay(250);
+    }
+  };
+
+  const send = (payload) => {
+    server.stdin.write(`${JSON.stringify(payload)}\n`);
+  };
+
+  try {
+    await delay(2000);
+    if (server.exitCode !== null) {
+      throw new Error(`server exited early: ${stderr || '(no stderr)'}`);
+    }
+
+    stdout = '';
+    send({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'ci-smoke', version: '1.0.0' },
+      },
+    });
+
+    await delay(1000);
+    const init = parseResponses(stdout).find((message) => message?.id === 1 && message?.result?.serverInfo);
+    if (!init) {
+      throw new Error('missing initialize response');
+    }
+    if (!init.result?.capabilities?.prompts) {
+      throw new Error('missing prompts capability');
+    }
+
+    stdout = '';
+    send({ jsonrpc: '2.0', method: 'notifications/initialized' });
+    send({ jsonrpc: '2.0', id: 2, method: 'prompts/list', params: {} });
+    await delay(1000);
+
+    const prompts = parseResponses(stdout).find((message) => message?.id === 2 && Array.isArray(message?.result?.prompts));
+    if (!prompts || prompts.result.prompts.length < 2) {
+      throw new Error('missing prompts/list response');
+    }
+
+    stdout = '';
+    send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+
+    await delay(1500);
+    const tools = parseResponses(stdout).find((message) => message?.id === 2 && Array.isArray(message?.result?.tools));
+    if (!tools || tools.result.tools.length === 0) {
+      throw new Error('missing tools/list response');
+    }
+
+    await connectWebSocket(`ws://${host}:${port}/visualizer`);
+    await connectWebSocket(`ws://${host}:${port}/godot`);
+
+    console.log(`ci smoke passed with ${tools.result.tools.length} tools on ${host}:${port}`);
+    await cleanup();
+  } catch (error) {
+    await cleanup();
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}
+
+await main();

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,8 @@ import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   CallToolRequestSchema,
   ErrorCode,
+  GetPromptRequestSchema,
+  ListPromptsRequestSchema,
   ListToolsRequestSchema,
   McpError,
 } from '@modelcontextprotocol/sdk/types.js';
@@ -32,6 +34,7 @@ import { GodotDAPClient, createDAPTools, handleDAPTool } from './dap_client.js';
 import { mapProject } from './gdscript_parser.js';
 import { serveVisualization, setProjectPath, stopVisualizationServer } from './visualizer-server.js';
 import { GodotBridge, getDefaultBridge } from './godot-bridge.js';
+import { getPrompt, listPrompts } from './prompts.js';
 
 // Check if debug mode is enabled
 const DEBUG_MODE: boolean = process.env.DEBUG === 'true';
@@ -239,6 +242,7 @@ class GodotServer {
       {
         capabilities: {
           tools: {},
+          prompts: {},
           resources: {},
         },
       }
@@ -993,6 +997,14 @@ class GodotServer {
    * Set up the tool handlers for the MCP server
    */
   private setupToolHandlers() {
+    this.server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+      return listPrompts(request.params?.cursor);
+    });
+
+    this.server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+      return getPrompt(request.params.name, request.params.arguments);
+    });
+
     // Define available tools
     this.server.setRequestHandler(ListToolsRequestSchema, async (request) => {
       const allTools: MCPToolDefinition[] = [

--- a/src/prompts.ts
+++ b/src/prompts.ts
@@ -1,0 +1,193 @@
+import {
+  ErrorCode,
+  McpError,
+  type GetPromptResult,
+  type ListPromptsResult,
+  type Prompt,
+} from '@modelcontextprotocol/sdk/types.js';
+
+type PromptArgs = Record<string, string> | undefined;
+
+type PromptTemplate = {
+  prompt: Prompt;
+  render: (args: PromptArgs) => GetPromptResult;
+};
+
+const PROMPTS_PAGE_SIZE = 20;
+
+function getTrimmedArg(args: PromptArgs, key: string): string | undefined {
+  const value = args?.[key];
+  if (typeof value !== 'string') {
+    return undefined;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+function requireArg(args: PromptArgs, key: string, promptName: string): string {
+  const value = getTrimmedArg(args, key);
+  if (!value) {
+    throw new McpError(ErrorCode.InvalidParams, `Prompt '${promptName}' requires argument '${key}'`);
+  }
+
+  return value;
+}
+
+const promptTemplates: PromptTemplate[] = [
+  {
+    prompt: {
+      name: 'godot.scene_bootstrap',
+      title: 'Godot Scene Bootstrap',
+      description: 'Generate a deterministic scene bootstrap plan and starter GDScript wiring for a new gameplay scene.',
+      arguments: [
+        {
+          name: 'project_path',
+          description: 'Absolute path to the Godot project directory.',
+          required: true,
+        },
+        {
+          name: 'scene_path',
+          description: 'Scene path to create, for example: res://scenes/Player.tscn',
+          required: true,
+        },
+        {
+          name: 'root_node_type',
+          description: 'Root node type for the scene. Defaults to Node2D.',
+        },
+        {
+          name: 'feature_goal',
+          description: 'Short feature goal to guide node and script choices.',
+        },
+      ],
+    },
+    render: (args: PromptArgs): GetPromptResult => {
+      const projectPath = requireArg(args, 'project_path', 'godot.scene_bootstrap');
+      const scenePath = requireArg(args, 'scene_path', 'godot.scene_bootstrap');
+      const rootNodeType = getTrimmedArg(args, 'root_node_type') || 'Node2D';
+      const featureGoal = getTrimmedArg(args, 'feature_goal') || 'Create a playable prototype with clear input and movement behavior.';
+
+      return {
+        description: 'Deterministic checklist for creating and wiring a new Godot scene.',
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: [
+                'Bootstrap a Godot scene using this deterministic sequence:',
+                `- Project path: ${projectPath}`,
+                `- Scene path: ${scenePath}`,
+                `- Root node type: ${rootNodeType}`,
+                `- Goal: ${featureGoal}`,
+                '',
+                'Execute in order:',
+                '1) Call project.info to confirm project metadata and main scene.',
+                `2) Call scene.create with scene_path='${scenePath}' and root_node_type='${rootNodeType}'.`,
+                '3) Add core nodes with scene.node.add (or add_node), then save the scene.',
+                '4) Create or modify the attached script with script.create/script.modify using typed exports for tunable values.',
+                '5) Run editor.run on the same project path, collect editor.debug_output, and fix top blocking errors.',
+                '6) Return a concise summary containing created nodes, script path, and unresolved risks.',
+              ].join('\n'),
+            },
+          },
+        ],
+      };
+    },
+  },
+  {
+    prompt: {
+      name: 'godot.debug_triage',
+      title: 'Godot Debug Triage',
+      description: 'Run a focused Godot debug triage loop from reproduction to verified fix.',
+      arguments: [
+        {
+          name: 'project_path',
+          description: 'Absolute path to the Godot project directory.',
+          required: true,
+        },
+        {
+          name: 'error_excerpt',
+          description: 'Error excerpt from Godot output or debugger panel.',
+          required: true,
+        },
+        {
+          name: 'repro_steps',
+          description: 'Optional reproduction steps observed by the developer.',
+        },
+      ],
+    },
+    render: (args: PromptArgs): GetPromptResult => {
+      const projectPath = requireArg(args, 'project_path', 'godot.debug_triage');
+      const errorExcerpt = requireArg(args, 'error_excerpt', 'godot.debug_triage');
+      const reproSteps = getTrimmedArg(args, 'repro_steps') || 'No reproduction steps provided.';
+
+      return {
+        description: 'Deterministic debug triage workflow for Godot runtime/editor errors.',
+        messages: [
+          {
+            role: 'user',
+            content: {
+              type: 'text',
+              text: [
+                'Triage and fix this Godot issue with deterministic steps:',
+                `- Project path: ${projectPath}`,
+                `- Error excerpt: ${errorExcerpt}`,
+                `- Repro steps: ${reproSteps}`,
+                '',
+                'Workflow:',
+                '1) Call editor.run for the target project and reproduce once.',
+                '2) Collect logs with editor.debug_output and parse_error_log; isolate the first root-cause error.',
+                '3) Use lsp.diagnostics/lsp_get_hover on the implicated script(s) before editing.',
+                '4) Apply the smallest fix with script.modify or scene/resource tools.',
+                '5) Re-run editor.run and confirm the original error excerpt no longer appears.',
+                '6) Report root cause, changed files, and any follow-up checks.',
+              ].join('\n'),
+            },
+          },
+        ],
+      };
+    },
+  },
+];
+
+const promptTemplatesByName = new Map(promptTemplates.map((template) => [template.prompt.name, template]));
+
+function parsePromptsListCursor(cursor: unknown, total: number): number {
+  if (typeof cursor !== 'string' || cursor.length === 0) {
+    return 0;
+  }
+
+  const offset = Number.parseInt(cursor, 10);
+  if (!Number.isInteger(offset) || offset < 0 || offset > total) {
+    throw new McpError(ErrorCode.InvalidParams, `Invalid prompts/list cursor: ${cursor}`);
+  }
+
+  return offset;
+}
+
+export function listPrompts(cursor: unknown): ListPromptsResult {
+  const promptDefs = promptTemplates.map((template) => template.prompt);
+  const start = parsePromptsListCursor(cursor, promptDefs.length);
+  const end = Math.min(start + PROMPTS_PAGE_SIZE, promptDefs.length);
+  const page = promptDefs.slice(start, end);
+
+  if (end < promptDefs.length) {
+    return {
+      prompts: page,
+      nextCursor: String(end),
+    };
+  }
+
+  return { prompts: page };
+}
+
+export function getPrompt(name: string, args?: Record<string, string>): GetPromptResult {
+  const template = promptTemplatesByName.get(name);
+  if (!template) {
+    const available = promptTemplates.map((entry) => entry.prompt.name).join(', ');
+    throw new McpError(ErrorCode.InvalidParams, `Unknown prompt: ${name}. Available prompts: ${available}`);
+  }
+
+  return template.render(args);
+}

--- a/test-bridge.mjs
+++ b/test-bridge.mjs
@@ -4,6 +4,7 @@
  * Tests: MCP server startup, WebSocket bridge, tool routing
  */
 import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
 import { WebSocket } from 'ws';
 import { setTimeout as delay } from 'node:timers/promises';
 
@@ -12,10 +13,8 @@ const bridgePortRaw = process.env.GODOT_BRIDGE_PORT || process.env.MCP_BRIDGE_PO
 const parsedBridgePort = Number.parseInt(bridgePortRaw || '', 10);
 const BRIDGE_PORT = Number.isInteger(parsedBridgePort) && parsedBridgePort >= 1 && parsedBridgePort <= 65535
   ? parsedBridgePort
-  : 6505;
+  : null;
 const BRIDGE_HOST = process.env.GOPEAK_BRIDGE_HOST || process.env.GODOT_BRIDGE_HOST || '127.0.0.1';
-const GODOT_WS_URL = `ws://${BRIDGE_HOST}:${BRIDGE_PORT}/godot`;
-const VIZ_WS_URL = `ws://${BRIDGE_HOST}:${BRIDGE_PORT}/visualizer`;
 const GODOT_PATH = process.env.GODOT_PATH || '/home/doyun/Apps/godot-4.6-rc2/Godot_v4.6-rc2_linux.x86_64';
 
 let passed = 0;
@@ -54,14 +53,46 @@ function chooseTool(toolNames, preferred) {
   return preferred.find(Boolean);
 }
 
+async function reserveBridgePort() {
+  if (BRIDGE_PORT) {
+    return BRIDGE_PORT;
+  }
+
+  return await new Promise((resolve, reject) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', reject);
+    server.listen(0, BRIDGE_HOST, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Failed to reserve bridge port')));
+        return;
+      }
+
+      const { port } = address;
+      server.close((error) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+  });
+}
+
 // --- Main test ---
 async function main() {
   console.log('\n🧪 Godot MCP Bridge Integration Test\n');
+  const bridgePort = await reserveBridgePort();
+  const godotWsUrl = `ws://${BRIDGE_HOST}:${bridgePort}/godot`;
+  const vizWsUrl = `ws://${BRIDGE_HOST}:${bridgePort}/visualizer`;
 
   // 1. Start MCP server
   console.log('📦 Starting MCP server...');
   const server = spawn('node', [MCP_SERVER], {
-    env: { ...process.env, GODOT_PATH, DEBUG: 'true', GOPEAK_TOOL_PROFILE: 'compact', GOPEAK_BRIDGE_PORT: String(BRIDGE_PORT), GOPEAK_BRIDGE_HOST: BRIDGE_HOST },
+    env: { ...process.env, GODOT_PATH, DEBUG: 'true', GOPEAK_TOOL_PROFILE: 'compact', GOPEAK_BRIDGE_PORT: String(bridgePort), GOPEAK_BRIDGE_HOST: BRIDGE_HOST },
     stdio: ['pipe', 'pipe', 'pipe'],
   });
 
@@ -98,6 +129,11 @@ async function main() {
     if (caps.serverInfo) {
       ok(`Server: ${caps.serverInfo.name} v${caps.serverInfo.version}`);
     }
+    if (caps.capabilities?.prompts) {
+      ok('Server advertises prompts capability');
+    } else {
+      fail('prompts capability', 'Missing capabilities.prompts in initialize response');
+    }
   } else {
     fail('MCP initialize', 'No valid response. stdout: ' + stdout.substring(0, 200));
   }
@@ -107,6 +143,60 @@ async function main() {
   await delay(500);
 
   // 4. List tools
+  console.log('\n🧠 Testing MCP prompts...');
+  stdout = '';
+  server.stdin.write(rpcMsg('prompts/list'));
+  await delay(1000);
+
+  const promptListResponses = parseResponses(stdout);
+  const promptListResult = promptListResponses.find(response => response.result?.prompts)?.result;
+  if (promptListResult?.prompts?.length >= 2) {
+    ok(`prompts/list returned ${promptListResult.prompts.length} prompt(s)`);
+    const promptNames = new Set(promptListResult.prompts.map(prompt => prompt.name));
+    if (promptNames.has('godot.scene_bootstrap') && promptNames.has('godot.debug_triage')) {
+      ok('Expected Godot prompts are listed');
+    } else {
+      fail('prompt listing', `Expected godot.scene_bootstrap and godot.debug_triage, got: ${Array.from(promptNames).join(', ')}`);
+    }
+  } else {
+    fail('prompts/list', 'No valid prompt list response');
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('prompts/get', {
+    name: 'godot.scene_bootstrap',
+    arguments: {
+      project_path: '/tmp/demo-project',
+      scene_path: 'res://scenes/Player.tscn',
+    },
+  }));
+  await delay(1000);
+
+  const promptGetResponses = parseResponses(stdout);
+  const promptGetResult = promptGetResponses.find(response => response.result?.messages)?.result;
+  if (promptGetResult?.messages?.length > 0) {
+    const promptText = promptGetResult.messages.map(message => message?.content?.text || '').join('\n');
+    if (promptText.includes('/tmp/demo-project') && promptText.includes('res://scenes/Player.tscn')) {
+      ok('prompts/get returns templated prompt content');
+    } else {
+      fail('prompts/get template args', 'Prompt content did not include expected argument values');
+    }
+  } else {
+    fail('prompts/get', 'No valid prompt response for godot.scene_bootstrap');
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('prompts/get', { name: 'godot.unknown_prompt', arguments: {} }));
+  await delay(1000);
+  const unknownPromptResponses = parseResponses(stdout);
+  const unknownPromptError = unknownPromptResponses.find(response => response.error)?.error;
+  if (unknownPromptError?.message?.includes('Unknown prompt')) {
+    ok('prompts/get returns clear error for unknown prompt');
+  } else {
+    fail('unknown prompt handling', 'Expected explicit unknown prompt error');
+  }
+
+  // 5. List tools
   async function listAllTools() {
     const allTools = [];
     let cursor;
@@ -171,7 +261,7 @@ async function main() {
     fail('tools/list', error.message);
   }
 
-  // 5. Call get_editor_status (should show disconnected)
+  // 6. Call get_editor_status (should show disconnected)
   console.log('\n🔌 Testing get_editor_status (no Godot connected)...');
   stdout = '';
   server.stdin.write(rpcMsg('tools/call', {
@@ -198,7 +288,7 @@ async function main() {
     fail('get_editor_status', 'No response');
   }
 
-  // 6. Test a migrated tool (should fail gracefully when no Godot)
+  // 7. Test a migrated tool (should fail gracefully when no Godot)
   console.log('\n🎮 Testing migrated tool without Godot connected...');
   stdout = '';
   server.stdin.write(rpcMsg('tools/call', {
@@ -224,11 +314,11 @@ async function main() {
     fail('create_scene without Godot', 'No response');
   }
 
-  // 7. Test visualizer WebSocket path routing
+  // 8. Test visualizer WebSocket path routing
   console.log('\n🖥️ Testing visualizer WebSocket path...');
   try {
     const vizWs = await new Promise((resolve, reject) => {
-      const socket = new WebSocket(VIZ_WS_URL);
+      const socket = new WebSocket(vizWsUrl);
       socket.on('open', () => resolve(socket));
       socket.on('error', reject);
       setTimeout(() => reject(new Error('Visualizer WS connect timeout')), 3000);
@@ -240,11 +330,11 @@ async function main() {
     fail('Visualizer WebSocket path', e.message);
   }
 
-  // 8. Test WebSocket connection (mock Godot client)
+  // 9. Test WebSocket connection (mock Godot client)
   console.log('\n🌐 Testing WebSocket bridge...');
   try {
     const ws = await new Promise((resolve, reject) => {
-      const socket = new WebSocket(GODOT_WS_URL);
+      const socket = new WebSocket(godotWsUrl);
       socket.on('open', () => resolve(socket));
       socket.on('error', reject);
       setTimeout(() => reject(new Error('WS connect timeout')), 3000);


### PR DESCRIPTION
## Summary
This PR implements the platform-direction foundation we discussed (inspired by mature MCP repos), while keeping compatibility with existing GoPeak workflows.

### 1) First-class MCP Prompt capability
- Added `src/prompts.ts` with `prompts/list` and `prompts/get` support
- Added two high-value prompts:
  - `godot.scene_bootstrap`
  - `godot.debug_triage`
- Integrated prompt handlers into `src/index.ts`
- Server now advertises `capabilities.prompts`

### 2) CI + verification baseline
- Added GitHub Actions workflow: `.github/workflows/ci.yml`
- CI now runs on push + pull_request
- CI steps:
  - `npm ci`
  - `npm run build`
  - `npm run typecheck`
  - `npm run test:ci`

### 3) Stable smoke + integration scripts
- Added `scripts/smoke-test.mjs` (dynamic bridge port to avoid local conflicts)
- Added npm scripts:
  - `typecheck`
  - `test:smoke`
  - `test:integration`
  - `test:ci`
  - `ci`

### 4) Version/release automation
- Added `scripts/bump-version.mjs` with support for `major|minor|patch|<explicit>` and `--dry-run`
- Syncs `package.json` + `server.json` (and README versioned refs when present)
- Added release guide: `docs/release-process.md`

### 5) Architecture and roadmap docs
- Added `docs/architecture.md` (current/target architecture, module boundaries, transport split)
- Added `docs/platform-roadmap.md` (P1/P2/P3 milestones, acceptance criteria, risks)
- Linked docs in `README.md`

## Compatibility notes
- Existing tools/resources behavior is preserved
- Prompt capability is additive
- Compact/full tool profile behavior remains intact

## Verification (local)
- `npm run ci` ✅
- `npm run test:integration` ✅ (25 passed, 0 failed)
- `node scripts/bump-version.mjs patch --dry-run` ✅

## Key files
- `src/prompts.ts`
- `src/index.ts`
- `test-bridge.mjs`
- `.github/workflows/ci.yml`
- `scripts/smoke-test.mjs`
- `scripts/bump-version.mjs`
- `docs/architecture.md`
- `docs/platform-roadmap.md`
- `docs/release-process.md`
- `README.md`
- `package.json`
