### PR TITLE
fix: disable Godot debug flag by default

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -35,7 +35,8 @@ import { GodotBridge, getDefaultBridge } from './godot-bridge.js';
 
 // Check if debug mode is enabled
 const DEBUG_MODE: boolean = process.env.DEBUG === 'true';
-const GODOT_DEBUG_MODE: boolean = true; // Always use GODOT DEBUG MODE
+// Godot debug flag defaults to false, but follows DEBUG=true for easier troubleshooting.
+const GODOT_DEBUG_MODE_DEFAULT: boolean = process.env.GODOT_DEBUG === 'true' || DEBUG_MODE;
 
 const execAsync = promisify(exec);
 
@@ -93,6 +94,7 @@ class GodotServer {
   private operationsScriptPath: string;
   private validatedPaths: Map<string, boolean> = new Map();
   private strictPathValidation: boolean = false;
+  private godotDebugMode: boolean = GODOT_DEBUG_MODE_DEFAULT;
   private lspClient: GodotLSPClient | null = null;
   private dapClient: GodotDAPClient | null = null;
   private lastProjectPath: string | null = null;
@@ -196,7 +198,7 @@ class GodotServer {
     }
     // Apply configuration if provided
     let debugMode = DEBUG_MODE;
-    let godotDebugMode = GODOT_DEBUG_MODE;
+    let godotDebugMode = GODOT_DEBUG_MODE_DEFAULT;
 
     if (config) {
       if (config.debugMode !== undefined) {
@@ -222,6 +224,8 @@ class GodotServer {
         }
       }
     }
+
+    this.godotDebugMode = godotDebugMode;
 
     // Set the path to the operations script
     this.operationsScriptPath = join(__dirname, 'scripts', 'godot_operations.gd');
@@ -837,7 +841,7 @@ class GodotServer {
 
 
       // Add debug arguments if debug mode is enabled
-      const debugArgs = GODOT_DEBUG_MODE ? ['--debug-godot'] : [];
+      const debugArgs = this.godotDebugMode ? ['--debug-godot'] : [];
 
       // Construct the command with the operation and JSON parameters
       const cmd = [


### PR DESCRIPTION
## Summary\n- replace hardcoded `GODOT_DEBUG_MODE = true` with env-driven default\n- default to `false`, but enable when `DEBUG=true` or `GODOT_DEBUG=true`\n- honor constructor override via `config.godotDebugMode` at runtime\n\n## Why\nThe previous hardcoded setting always added `--debug-godot` to headless execution, which increases noisy output and can affect behavior in normal runs.\n\n## Validation\n- npm run build (passes)\n- verified command args now use `this.godotDebugMode` instead of constant\n