### PR TITLE
fix: harden LSP path checks and security CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,13 +2,17 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
+      - beta
   pull_request:
+    branches:
+      - main
+      - beta
 
 jobs:
-  build-and-test:
+  build-test-audit:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -25,12 +29,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Typecheck
-        run: npx tsc --noEmit
+      - name: Test
+        run: npm test
 
-      - name: Smoke / integration test
-        env:
-          GODOT_PATH: /bin/true
-          GOPEAK_BRIDGE_HOST: 127.0.0.1
-          GOPEAK_BRIDGE_PORT: 6505
-        run: npm run test:ci
+      - name: Audit production dependencies
+        run: npm audit --omit=dev

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,22 +1,22 @@
 {
   "name": "gopeak",
-  "version": "2.1.0",
+  "version": "2.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gopeak",
-      "version": "2.1.0",
+      "version": "2.2.1",
       "license": "MIT",
       "dependencies": {
-        "@modelcontextprotocol/sdk": "^1.27.0",
-        "axios": "^1.7.9",
+        "@modelcontextprotocol/sdk": "^1.27.1",
+        "axios": "^1.13.6",
         "fs-extra": "^11.2.0",
         "ws": "^8.18.0"
       },
       "bin": {
-        "godot-mcp": "build/index.js",
-        "gopeak": "build/index.js"
+        "godot-mcp": "build/cli.js",
+        "gopeak": "build/cli.js"
       },
       "devDependencies": {
         "@types/node": "^20.11.24",
@@ -458,9 +458,9 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.19.9",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.9.tgz",
-      "integrity": "sha512-vHL6w3ecZsky+8P5MD+eFfaGTyCeOHUIFYMGpQGbrBTSmNNoxv0if69rEZ5giu36weC5saFuznL411gRX7bJDw==",
+      "version": "1.19.11",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.11.tgz",
+      "integrity": "sha512-dr8/3zEaB+p0D2n/IUrlPF1HZm586qgJNXK1a9fhg/PzdtkK7Ksd5l312tJX2yBuALqDYBlG20QEbayqPyxn+g==",
       "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
@@ -470,9 +470,9 @@
       }
     },
     "node_modules/@modelcontextprotocol/sdk": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.0.tgz",
-      "integrity": "sha512-qOdO524oPMkUsOJTrsH9vz/HN3B5pKyW+9zIW51A9kDMVe7ON70drz1ouoyoyOcfzc+oxhkQ6jWmbyKnlWmYqA==",
+      "version": "1.27.1",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.27.1.tgz",
+      "integrity": "sha512-sr6GbP+4edBwFndLbM60gf07z0FQ79gaExpnsjMGePXqFcSSb7t6iscpjk9DhFhwd+mTEQrzNafGP8/iGGFYaA==",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^1.19.9",
@@ -607,13 +607,13 @@
       "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.12.2.tgz",
-      "integrity": "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==",
+      "version": "1.13.6",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.6.tgz",
+      "integrity": "sha512-ChTCHMouEe2kn713WHbQGcuYrr6fXTBiu460OTwWrWob16g1bXn4vtz07Ope7ewMozJAnEquLk5lWQWtBig9DQ==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.4",
+        "follow-redirects": "^1.15.11",
+        "form-data": "^4.0.5",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -1078,9 +1078,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.9.tgz",
-      "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==",
+      "version": "1.15.11",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
       "funding": [
         {
           "type": "individual",
@@ -1098,9 +1098,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.4.tgz",
-      "integrity": "sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -1249,9 +1249,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.1",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.1.tgz",
-      "integrity": "sha512-hi9afu8g0lfJVLolxElAZGANCTTl6bewIdsRNhaywfP9K8BPf++F2z6OLrYGIinUwpRKzbZHMhPwvc0ZEpAwGw==",
+      "version": "4.12.5",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
+      "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "scripts": {
     "build": "tsc && node scripts/build-visualizer.js && node scripts/build.js",
     "typecheck": "tsc --noEmit",
+    "test": "npm run test:ci",
     "test:smoke": "node scripts/smoke-test.mjs",
     "test:integration": "node test-bridge.mjs",
     "test:ci": "npm run test:smoke",
@@ -31,8 +32,8 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.27.0",
-    "axios": "^1.7.9",
+    "@modelcontextprotocol/sdk": "^1.27.1",
+    "axios": "^1.13.6",
     "fs-extra": "^11.2.0",
     "ws": "^8.18.0"
   },
@@ -41,6 +42,10 @@
     "@types/ws": "^8.5.12",
     "esbuild": "^0.24.2",
     "typescript": "^5.3.3"
+  },
+  "overrides": {
+    "@hono/node-server": "^1.19.11",
+    "hono": "^4.12.5"
   },
   "license": "MIT",
   "repository": {

--- a/src/lsp_client.ts
+++ b/src/lsp_client.ts
@@ -1,6 +1,6 @@
-import { readFile } from 'node:fs/promises';
+import { readFile, realpath } from 'node:fs/promises';
 import { createConnection, type Socket } from 'node:net';
-import { dirname, resolve } from 'node:path';
+import { dirname, resolve, sep } from 'node:path';
 import { pathToFileURL } from 'node:url';
 
 type PendingRequest = {
@@ -555,6 +555,46 @@ function normalizeLSPError(error: unknown): string {
   return String(error);
 }
 
+function normalizePathForComparison(pathValue: string): string {
+  const resolved = resolve(pathValue);
+  return process.platform === 'win32' ? resolved.toLowerCase() : resolved;
+}
+
+function isPathWithinRoot(rootPath: string, candidatePath: string): boolean {
+  const normalizedRoot = normalizePathForComparison(rootPath);
+  const normalizedCandidate = normalizePathForComparison(candidatePath);
+  const rootPrefix = normalizedRoot.endsWith(sep) ? normalizedRoot : `${normalizedRoot}${sep}`;
+
+  return normalizedCandidate === normalizedRoot || normalizedCandidate.startsWith(rootPrefix);
+}
+
+async function resolveLSPPaths(
+  projectPathValue: string,
+  scriptPathValue: string
+): Promise<{ projectPath: string; scriptPath: string }> {
+  const requestedProjectPath = resolve(projectPathValue);
+  let projectPath: string;
+  try {
+    projectPath = await realpath(requestedProjectPath);
+  } catch {
+    throw new Error(`Project path does not exist: ${requestedProjectPath}`);
+  }
+
+  const requestedScriptPath = resolve(projectPath, scriptPathValue);
+  let scriptPath: string;
+  try {
+    scriptPath = await realpath(requestedScriptPath);
+  } catch {
+    throw new Error(`Script file does not exist: ${requestedScriptPath}`);
+  }
+
+  if (!isPathWithinRoot(projectPath, scriptPath)) {
+    throw new Error('scriptPath resolves outside the project root boundary.');
+  }
+
+  return { projectPath, scriptPath };
+}
+
 export async function handleLSPTool(
   client: GodotLSPClient,
   toolName: string,
@@ -577,8 +617,7 @@ export async function handleLSPTool(
       throw new Error('Missing required argument: scriptPath');
     }
 
-    const projectPath = resolve(projectPathValue);
-    const scriptPath = resolve(projectPath, scriptPathValue);
+    const { projectPath, scriptPath } = await resolveLSPPaths(projectPathValue, scriptPathValue);
     const content = await readFile(scriptPath, 'utf8');
 
     await client.initialize(projectPath);


### PR DESCRIPTION
## Summary
- harden `handleLSPTool` path handling with `realpath` + strict project-root prefix guard before file reads
- bump vulnerable prod deps: `@modelcontextprotocol/sdk` to `^1.27.1`, `axios` to `^1.13.6`
- add `overrides` for audited transitive vulns (`@hono/node-server`, `hono`) and regenerate lockfile
- add `npm test` fallback script and extend CI to run build, test, and `npm audit --omit=dev`

## Verification
- `npm run build`
- `npm test`
- `npm audit --omit=dev`

## Notes
- `src/index.ts` already uses ESM-safe `createConnection` import (`node:net`), so no runtime `require('node:net')` replacement was needed in this branch.
