### PR TITLE
Fix ClassDB MCP JSON responses and restore node path helper

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -4932,6 +4932,29 @@ class GodotServer {
       .filter((v) => v !== null);
   }
 
+  private extractLastJsonLine(stdout: string): string | null {
+    const lines = stdout
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    for (let i = lines.length - 1; i >= 0; i -= 1) {
+      const line = lines[i];
+      if (!(line.startsWith('{') || line.startsWith('['))) {
+        continue;
+      }
+
+      try {
+        JSON.parse(line);
+        return line;
+      } catch {
+        continue;
+      }
+    }
+
+    return null;
+  }
+
   /**
    * Capture/update current intent snapshot
    */
@@ -5995,7 +6018,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6058,7 +6081,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6375,7 +6398,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6436,7 +6459,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6616,7 +6639,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6735,7 +6758,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6794,7 +6817,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6848,7 +6871,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6902,7 +6925,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -6955,7 +6978,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -7012,7 +7035,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -7223,7 +7246,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -7487,7 +7510,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -8405,7 +8428,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -8638,7 +8661,7 @@ class GodotServer {
       }
 
       return {
-        content: [{ type: 'text', text: stdout.trim() }],
+        content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
       };
     } catch (error: any) {
       return this.createErrorResponse(
@@ -9525,7 +9548,18 @@ uniform float dissolve_amount : hint_range(0.0, 1.0) = 0.0;
     if (args?.category) params.category = args.category;
     if (args?.instantiableOnly !== undefined) params.instantiable_only = args.instantiableOnly;
     if (args?.instantiable_only !== undefined) params.instantiable_only = args.instantiable_only;
-    return await this.executeOperation('query_classes', params, projectPath);
+
+    const { stdout, stderr } = await this.executeOperation('query_classes', params, projectPath);
+    if (stderr && stderr.trim()) {
+      return this.createErrorResponse(`Failed to query classes: ${stderr.trim()}`, [
+        'Check the project path and ensure project.godot exists',
+        'Verify the category/filter arguments are valid',
+      ]);
+    }
+
+    return {
+      content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
+    };
   }
 
   /**
@@ -9545,7 +9579,18 @@ uniform float dissolve_amount : hint_range(0.0, 1.0) = 0.0;
     };
     if (args?.includeInherited !== undefined) params.include_inherited = args.includeInherited;
     if (args?.include_inherited !== undefined) params.include_inherited = args.include_inherited;
-    return await this.executeOperation('query_class_info', params, projectPath);
+
+    const { stdout, stderr } = await this.executeOperation('query_class_info', params, projectPath);
+    if (stderr && stderr.trim()) {
+      return this.createErrorResponse(`Failed to query class info: ${stderr.trim()}`, [
+        'Check that the class name exists in the current Godot version',
+        'Verify the project path and ClassDB availability',
+      ]);
+    }
+
+    return {
+      content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
+    };
   }
 
   /**
@@ -9560,9 +9605,17 @@ uniform float dissolve_amount : hint_range(0.0, 1.0) = 0.0;
     if (!className) {
       throw new McpError(ErrorCode.InvalidParams, 'className is required');
     }
-    return await this.executeOperation('inspect_inheritance', {
+    const { stdout, stderr } = await this.executeOperation('inspect_inheritance', {
       class_name: className,
     }, projectPath);
+    if (stderr && stderr.trim()) {
+      return this.createErrorResponse(`Failed to inspect inheritance: ${stderr.trim()}`, [
+        'Check that the class name exists in the current Godot version',
+      ]);
+    }
+    return {
+      content: [{ type: 'text', text: this.extractLastJsonLine(stdout) || stdout.trim() }],
+    };
   }
 
   /**

--- a/src/scripts/godot_operations.gd
+++ b/src/scripts/godot_operations.gd
@@ -2835,6 +2835,10 @@ func get_node_by_path_v2(scene_root: Node, node_path: String) -> Node:
     
     return scene_root.get_node_or_null(clean_path)
 
+# Backward-compatible alias for newer helpers that still call the old name
+func get_node_from_path(scene_root: Node, node_path: String) -> Node:
+    return get_node_by_path_v2(scene_root, node_path)
+
 # Helper function to build node tree structure recursively
 func build_node_tree(node: Node, current_depth: int, max_depth: int, include_properties: bool) -> Dictionary:
     var result = {

--- a/test-bridge.mjs
+++ b/test-bridge.mjs
@@ -16,6 +16,7 @@ const BRIDGE_PORT = Number.isInteger(parsedBridgePort) && parsedBridgePort >= 1 
   : null;
 const BRIDGE_HOST = process.env.GOPEAK_BRIDGE_HOST || process.env.GODOT_BRIDGE_HOST || '127.0.0.1';
 const GODOT_PATH = process.env.GODOT_PATH || '/home/doyun/Apps/godot-4.6-rc2/Godot_v4.6-rc2_linux.x86_64';
+const TEST_PROJECT = process.env.GOPEAK_TEST_PROJECT || '/home/doyun/gopeak-smoke-test';
 
 let passed = 0;
 let failed = 0;
@@ -316,6 +317,69 @@ async function main() {
     fail('tools/list', error.message);
   }
 
+  // 5.5 Regression: class introspection tools should return structured MCP content
+  console.log('\n🏛️ Testing ClassDB introspection tools...');
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: 'query_classes',
+    arguments: {
+      projectPath: TEST_PROJECT,
+      category: 'node2d',
+      filter: 'sprite',
+      instantiableOnly: true,
+    }
+  }));
+  await delay(1500);
+
+  const queryClassesResponses = parseResponses(stdout);
+  const queryClassesPayload = parseTextContent(queryClassesResponses.find(response => response.result?.content));
+  if (queryClassesPayload && Array.isArray(queryClassesPayload.classes)) {
+    ok(`query_classes returned structured JSON (${queryClassesPayload.classes.length} classes)`);
+  } else {
+    fail('query_classes structured response', JSON.stringify(queryClassesResponses[0] || null));
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: 'query_class_info',
+    arguments: {
+      projectPath: TEST_PROJECT,
+      className: 'Node2D',
+    }
+  }));
+  await delay(1500);
+
+  const queryClassInfoResponses = parseResponses(stdout);
+  const queryClassInfoPayload = parseTextContent(queryClassInfoResponses.find(response => response.result?.content));
+  if (queryClassInfoPayload && queryClassInfoPayload.class_name === 'Node2D' && Array.isArray(queryClassInfoPayload.methods)) {
+    ok(`query_class_info returned structured JSON (${queryClassInfoPayload.methods.length} methods)`);
+  } else {
+    fail('query_class_info structured response', JSON.stringify(queryClassInfoResponses[0] || null));
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: 'search_project',
+    arguments: {
+      projectPath: TEST_PROJECT,
+      query: 'extends CharacterBody2D',
+      fileTypes: ['gd'],
+      maxResults: 10,
+    }
+  }));
+  await delay(1500);
+
+  const searchProjectResponses = parseResponses(stdout);
+  const searchProjectText = searchProjectResponses
+    .flatMap((response) => response?.result?.content || [])
+    .map((chunk) => chunk?.text || '')
+    .join('\n');
+  if (searchProjectText.includes('player.gd') || searchProjectText.includes('CharacterBody2D')) {
+    ok('search_project runs without script parse errors');
+  } else {
+    fail('search_project regression', searchProjectText.substring(0, 400) || JSON.stringify(searchProjectResponses[0] || null));
+  }
+
   // 6. Call get_editor_status (should show disconnected)
   console.log('\n🔌 Testing get_editor_status (no Godot connected)...');
   stdout = '';
@@ -399,7 +463,7 @@ async function main() {
     // Send godot_ready
     ws.send(JSON.stringify({
       type: 'godot_ready',
-      project_path: '/home/doyun/gopeak-smoke-test'
+      project_path: TEST_PROJECT
     }));
     await delay(500);
     ok('Sent godot_ready message');
@@ -448,7 +512,7 @@ async function main() {
     server.stdin.write(rpcMsg('tools/call', {
       name: sceneCreateToolName,
       arguments: {
-        project_path: '/home/doyun/gopeak-smoke-test',
+        project_path: TEST_PROJECT,
         scene_path: 'res://test_bridge.tscn',
         root_type: 'Node2D',
       }
@@ -465,7 +529,7 @@ async function main() {
       }
 
       if (
-        invokeMsg.args?.projectPath === '/home/doyun/gopeak-smoke-test'
+        invokeMsg.args?.projectPath === TEST_PROJECT
         && invokeMsg.args?.scenePath === 'res://test_bridge.tscn'
         && invokeMsg.args?.rootNodeType === 'Node2D'
       ) {


### PR DESCRIPTION
## Summary
- return clean JSON text for ClassDB MCP tools instead of raw exec output
- extract the final JSON line from noisy Godot stdout so MCP clients can parse `query_classes` and `query_class_info`
- restore the `get_node_from_path` compatibility alias used by newer GDScript helpers
- add integration regressions covering ClassDB tool payloads and `search_project`

## Verification
- `npm run build && npm run test:integration`
- `npm run ci`
- `npx tsc --noEmit --pretty false --project /home/doyun/godot-mcp/tsconfig.json`
