### PR TITLE
docs: package GoPeak CLI vs MCP validation artifacts for dev review

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ GoPeak also exposes two CLI bin names:
 - [Documentation Map](docs/README.md)
 - [Architecture](docs/architecture.md)
 - [Platform Roadmap](docs/platform-roadmap.md)
+- [GoPeak CLI vs MCP Validation Notes](docs/gopeak-cli-vs-mcp-validation.md)
 - [Unity-MCP Benchmark Plan](docs/unity-mcp-benchmark-plan.md)
 - [Release Process](docs/release-process.md)
 

--- a/benchmarks/gopeak-cli-vs-mcp.sample.json
+++ b/benchmarks/gopeak-cli-vs-mcp.sample.json
@@ -1,0 +1,131 @@
+{
+  "name": "gopeak-cli-vs-mcp-sample",
+  "repetitions": 3,
+  "tasks": [
+    {
+      "id": "script-create",
+      "family": "script-mutation",
+      "description": "Create a benchmark script in a real Godot project",
+      "cli": {
+        "command": [
+          "script",
+          "create",
+          "--project-path",
+          "/absolute/path/to/project",
+          "--script-path",
+          "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "--extends",
+          "Node"
+        ],
+        "interfaceText": "gopeak script create --project-path /absolute/path/to/project --script-path scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd --extends Node"
+      },
+      "mcp": {
+        "tool": "script.create",
+        "args": {
+          "projectPath": "/absolute/path/to/project",
+          "scriptPath": "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "extends": "Node"
+        }
+      }
+    },
+    {
+      "id": "script-modify",
+      "family": "script-mutation",
+      "description": "Append a deterministic function to the benchmark script",
+      "cli": {
+        "command": [
+          "script",
+          "modify",
+          "--project-path",
+          "/absolute/path/to/project",
+          "--script-path",
+          "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "--modifications",
+          "[{\"type\":\"add_function\",\"name\":\"benchmark_ping\",\"body\":\"return \\\"pong\\\"\",\"returnType\":\"String\"}]"
+        ],
+        "interfaceText": "gopeak script modify --project-path /absolute/path/to/project --script-path scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd --modifications '[...]'"
+      },
+      "mcp": {
+        "tool": "script.modify",
+        "args": {
+          "projectPath": "/absolute/path/to/project",
+          "scriptPath": "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "modifications": [
+            {
+              "type": "add_function",
+              "name": "benchmark_ping",
+              "body": "return \"pong\"",
+              "returnType": "String"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "editor-run",
+      "family": "run-debug",
+      "description": "Launch the project under debug",
+      "cli": {
+        "command": [
+          "editor",
+          "run",
+          "--project-path",
+          "/absolute/path/to/project"
+        ],
+        "interfaceText": "gopeak editor run --project-path /absolute/path/to/project"
+      },
+      "mcp": {
+        "tool": "editor.run",
+        "args": {
+          "projectPath": "/absolute/path/to/project"
+        }
+      }
+    },
+    {
+      "id": "debug-output",
+      "family": "run-debug",
+      "description": "Read captured debug output after running the project",
+      "cli": {
+        "command": [
+          "debug",
+          "output",
+          "--reason",
+          "benchmark"
+        ],
+        "interfaceText": "gopeak debug output --reason benchmark"
+      },
+      "mcp": {
+        "tool": "editor.debug_output",
+        "args": {
+          "reason": "benchmark"
+        }
+      }
+    },
+    {
+      "id": "project-export",
+      "family": "export-build",
+      "description": "Export the project using an existing preset",
+      "cli": {
+        "command": [
+          "project",
+          "export",
+          "--project-path",
+          "/absolute/path/to/project",
+          "--preset",
+          "Linux/X11",
+          "--output-path",
+          "/absolute/path/to/build/game.x86_64"
+        ],
+        "interfaceText": "gopeak project export --project-path /absolute/path/to/project --preset Linux/X11 --output-path /absolute/path/to/build/game.x86_64"
+      },
+      "mcp": {
+        "tool": "export.run",
+        "args": {
+          "projectPath": "/absolute/path/to/project",
+          "preset": "Linux/X11",
+          "outputPath": "/absolute/path/to/build/game.x86_64"
+        }
+      }
+    }
+  ]
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -9,6 +9,7 @@ This folder groups design and release references for GoPeak.
 
 ## Benchmark Planning
 
+- [gopeak-cli-vs-mcp-validation.md](./gopeak-cli-vs-mcp-validation.md): benchmark guardrails, shared-core readiness map, and code-quality review notes for the CLI-vs-MCP validation track.
 - [unity-mcp-benchmark-plan.md](./unity-mcp-benchmark-plan.md): Unity-MCP benchmark lens and execution tracks for parity hardening.
 
 ## Release

--- a/docs/gopeak-cli-vs-mcp-validation.md
+++ b/docs/gopeak-cli-vs-mcp-validation.md
@@ -1,0 +1,73 @@
+# GoPeak CLI vs MCP Validation Notes
+
+This document turns the approved validation plan into a repo-local execution guide for the current codebase. It is intentionally documentation-only: no product-positioning change is implied until benchmark evidence exists.
+
+## Current repo facts that constrain the benchmark
+
+- The public package and onboarding flow are still MCP-first: `README.md`, `package.json`, and `server.json` position GoPeak as an MCP server and route `gopeak` to MCP startup by default.
+- The current public CLI in `src/cli.ts` exposes lifecycle/support commands (`setup`, `check`, `notify`, `star`, `uninstall`, `version`, `help`) and otherwise falls through to `src/index.ts` to launch the MCP server.
+- Compact MCP is already the repository's token-efficiency baseline: `src/index.ts` defaults `GOPEAK_TOOL_PROFILE` to `compact`, and the README documents compact mode as the default profile.
+- Command-style execution already exists internally: many scene/script/project actions flow through `executeGodotOperation(...)` and `src/scripts/godot_operations.gd`, which is the best shared-core seam for a CLI-vs-MCP comparison.
+
+## Code-quality review for the benchmark surface
+
+### Strengths to preserve
+
+1. **Compact baseline is real, not hypothetical**
+   - `src/index.ts` defaults the tool exposure profile to `compact`.
+   - Dynamic groups keep the default schema smaller while allowing capability expansion on demand.
+2. **A shared execution seam already exists**
+   - `executeGodotOperation(...)` centralizes a large class of headless Godot operations.
+   - `src/scripts/godot_operations.gd` already accepts an operation name plus JSON parameters, which makes a thin CLI wrapper plausible.
+3. **Transport split is already documented**
+   - `docs/architecture.md` cleanly separates MCP client transport from the Godot bridge/editor/runtime transport.
+
+### Hotspots to watch before claiming a fair CLI win
+
+1. **Business logic is still concentrated in `src/index.ts`**
+   - The benchmark will be misleading if the CLI prototype duplicates MCP-side validation/normalization instead of reusing a shared helper.
+2. **Export/build paths are only partly shared today**
+   - `export_project` shells out directly to Godot CLI instead of using `godot_operations.gd`.
+   - Benchmark results for export/build should be labeled `mixed-path` unless both surfaces route through the same helper.
+3. **Discovery-heavy workflows remain MCP-shaped**
+   - Compact profile pagination, `tool_catalog`, and dynamic group activation are meaningful MCP capabilities, not overhead bugs.
+   - Any CLI comparison should call out where MCP's broader discovery surface is delivering extra value.
+
+## Shared-core readiness map
+
+| Task family | Current best comparison seam | Readiness | Notes |
+| --- | --- | --- | --- |
+| Scene/script mutation | `executeGodotOperation(...)` -> `src/scripts/godot_operations.gd` | Shared-core-ready | Best first benchmark family because MCP and CLI can plausibly hit the same engine-side path. |
+| Run/export/build | direct Godot process launch in `src/index.ts` plus existing project helpers | Mixed | Export currently bypasses `godot_operations.gd`; normalize the command runner before treating results as apples-to-apples. |
+| Debug/log retrieval | existing runtime/editor debug handlers in `src/index.ts` and bridge paths | MCP-coupled / Mixed | Good benchmark family, but note that editor/runtime coupling and streaming feedback are areas where MCP may retain an advantage. |
+| Tool discovery / capability search | `tool_catalog`, compact pagination, dynamic groups | MCP-coupled | Keep this as context, not a primary CLI-vs-MCP benchmark, because the CLI prototype is intentionally narrower. |
+
+## Benchmark guardrails
+
+1. Use `GOPEAK_TOOL_PROFILE=compact` as the primary MCP baseline.
+2. Keep prompts and task success criteria fixed across surfaces.
+3. Prefer shared helpers over duplicated argument parsing or result shaping.
+4. Label any benchmark that compares different underlying execution paths as `mixed-path` in the evidence.
+5. Preserve MCP compatibility checks in the final recommendation: `npx -y gopeak`, stdio startup, representative compact-profile tool access, and metadata consistency.
+
+## Documentation handoff for implementation + verification lanes
+
+### Implementation lane
+
+- Treat `src/cli.ts` as the public command entry, but keep the prototype narrow.
+- Prefer extracting shared helpers rather than embedding new behavior directly in the CLI switch.
+- Keep benchmark instrumentation surface-agnostic so evidence normalization can compare MCP and CLI runs directly.
+
+### Verification lane
+
+- Record per-run tokens, invocation count, wall-clock time, retries, and success/failure.
+- Report median values across at least 3 runs per path.
+- Flag `mixed-path` families separately from fully shared-core families.
+
+## Near-term recommendation
+
+Proceed with a **hybrid, benchmark-first** evaluation:
+
+- benchmark scene/script mutation first,
+- keep run/export/build in scope but label current path differences honestly,
+- treat discovery-heavy/editor-coupled flows as places where MCP may remain the better primary interface even if CLI wins on narrow, repetitive operations.

--- a/scripts/benchmark/cli-vs-mcp-benchmark.mjs
+++ b/scripts/benchmark/cli-vs-mcp-benchmark.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import process from 'node:process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const prototypePath = join(__dirname, 'gopeak-cli-prototype.mjs');
+const matrixPath = join(__dirname, 'cli-vs-mcp.matrix.json');
+const buildServerPath = join(repoRoot, 'build', 'index.js');
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      result._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = next;
+    i += 1;
+  }
+  return result;
+}
+
+function estimateTokens(value) {
+  return Math.max(1, Math.ceil(String(value).length / 4));
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function ensureProjectCopy(sourceProjectPath, label) {
+  const tempRoot = mkdtempSync(join(tmpdir(), `gopeak-bench-${label}-`));
+  const target = join(tempRoot, 'project');
+  cpSync(sourceProjectPath, target, { recursive: true });
+  return { tempRoot, projectPath: target };
+}
+
+function assertTask(task, projectPath, surfaceResult) {
+  const failures = [];
+  for (const assertion of task.assertions || []) {
+    if (assertion.type === 'path_exists') {
+      const fullPath = join(projectPath, assertion.path);
+      if (!existsSync(fullPath)) {
+        failures.push(`missing path: ${assertion.path}`);
+      }
+    }
+    if (assertion.type === 'file_contains') {
+      const fullPath = join(projectPath, assertion.path);
+      const content = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : '';
+      if (!content.includes(assertion.needle)) {
+        failures.push(`missing content in ${assertion.path}: ${assertion.needle}`);
+      }
+    }
+    if (assertion.type === 'stdout_nonempty') {
+      if (!String(surfaceResult.stdout || '').trim()) {
+        failures.push('stdout was empty');
+      }
+    }
+  }
+  return failures;
+}
+
+class McpClient {
+  constructor(env) {
+    this.nextId = 1;
+    this.pending = new Map();
+    this.stderr = '';
+    this.process = spawn(process.execPath, [buildServerPath], {
+      cwd: repoRoot,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const rl = createInterface({ input: this.process.stdout });
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      let payload;
+      try {
+        payload = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (typeof payload.id !== 'undefined' && this.pending.has(payload.id)) {
+        const { resolve: resolvePromise } = this.pending.get(payload.id);
+        this.pending.delete(payload.id);
+        resolvePromise(payload);
+      }
+    });
+    this.process.stderr.on('data', (chunk) => {
+      this.stderr += chunk.toString();
+    });
+  }
+
+  async request(method, params = {}, timeoutMs = 30000) {
+    const id = this.nextId += 1;
+    const payload = { jsonrpc: '2.0', id, method, params };
+    const serialized = JSON.stringify(payload);
+    const responsePromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timeout waiting for ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+      });
+    });
+    this.process.stdin.write(`${serialized}\n`);
+    return { response: await responsePromise, tokenEstimate: estimateTokens(serialized) };
+  }
+
+  async initialize() {
+    await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'cli-vs-mcp-benchmark', version: '1.0.0' },
+    });
+    this.process.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`);
+  }
+
+  async callTool(name, args) {
+    return await this.request('tools/call', { name, arguments: args });
+  }
+
+  async close() {
+    if (this.process.exitCode === null) {
+      this.process.stdin.end();
+      this.process.kill('SIGTERM');
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+}
+
+async function runCliTask(task, projectPath, godotPath) {
+  const args = [prototypePath, task.cli.command, '--projectPath', projectPath, '--godotPath', godotPath];
+  for (const [key, value] of Object.entries(task.cli.args || {})) {
+    args.push(`--${key}`);
+    args.push(typeof value === 'string' ? value : JSON.stringify(value));
+  }
+
+  const startedAt = Date.now();
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+  child.stdout.on('data', (chunk) => stdoutChunks.push(chunk.toString()));
+  child.stderr.on('data', (chunk) => stderrChunks.push(chunk.toString()));
+
+  const exitCode = await new Promise((resolve) => child.on('close', resolve));
+  const stdout = stdoutChunks.join('').trim();
+  const stderr = stderrChunks.join('').trim();
+  let parsed = null;
+  try {
+    parsed = stdout ? JSON.parse(stdout) : null;
+  } catch {}
+
+  return {
+    ok: exitCode === 0 && Boolean(parsed?.ok),
+    exitCode,
+    stdout,
+    stderr,
+    parsed,
+    durationMs: Date.now() - startedAt,
+    invocationCount: parsed?.invocationCount ?? 1,
+    interfaceTokenEstimate: parsed?.interfaceTokenEstimate ?? estimateTokens(args.slice(1).join(' ')),
+  };
+}
+
+async function runMcpTask(task, mcp, projectPath) {
+  const startedAt = Date.now();
+  let invocationCount = 0;
+  let interfaceTokenEstimate = 0;
+  let lastText = '';
+  const responses = [];
+
+  for (const call of task.mcp.calls) {
+    const args = { ...(call.args || {}), projectPath };
+    const { response, tokenEstimate } = await mcp.callTool(call.tool, args);
+    invocationCount += 1;
+    interfaceTokenEstimate += tokenEstimate;
+    responses.push(response);
+    const text = response?.result?.content?.map((part) => part?.text || '').join('\n') || '';
+    lastText = text;
+    if (response?.error) {
+      return {
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        invocationCount,
+        interfaceTokenEstimate,
+        stdout: lastText,
+        stderr: response.error.message || 'MCP error',
+        responses,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    durationMs: Date.now() - startedAt,
+    invocationCount,
+    interfaceTokenEstimate,
+    stdout: lastText,
+    stderr: '',
+    responses,
+  };
+}
+
+function summarize(results) {
+  const summary = {};
+  for (const surface of ['cli', 'mcp']) {
+    const surfaceRuns = results.filter((entry) => entry.surface === surface && entry.ok);
+    if (surfaceRuns.length === 0) {
+      summary[surface] = { okRuns: 0 };
+      continue;
+    }
+    summary[surface] = {
+      okRuns: surfaceRuns.length,
+      medianDurationMs: median(surfaceRuns.map((entry) => entry.durationMs)),
+      medianInvocationCount: median(surfaceRuns.map((entry) => entry.invocationCount)),
+      medianInterfaceTokenEstimate: median(surfaceRuns.map((entry) => entry.interfaceTokenEstimate)),
+    };
+  }
+  return summary;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const matrix = JSON.parse(readFileSync(matrixPath, 'utf8'));
+  const sourceProjectPath = resolve(args.projectPath || '/home/yun/gopeak-demo');
+  const selectedTaskIds = args.tasks ? String(args.tasks).split(',').map((item) => item.trim()) : matrix.tasks.map((task) => task.id);
+  const iterations = Math.max(1, Number.parseInt(args.iterations || '1', 10));
+  const godotPath = args.godotPath || process.env.GODOT_PATH || 'godot';
+
+  const mcp = new McpClient({
+    ...process.env,
+    GODOT_PATH: godotPath,
+    GOPEAK_TOOL_PROFILE: matrix.baseline?.mcpProfile || 'compact',
+  });
+  await mcp.initialize();
+
+  const runResults = [];
+  try {
+    for (const taskId of selectedTaskIds) {
+      const task = matrix.tasks.find((entry) => entry.id === taskId);
+      if (!task) {
+        throw new Error(`Unknown task id: ${taskId}`);
+      }
+
+      for (let iteration = 1; iteration <= iterations; iteration += 1) {
+        for (const surface of ['cli', 'mcp']) {
+          const fixture = ensureProjectCopy(sourceProjectPath, `${task.id}-${surface}-${iteration}`);
+          try {
+            const surfaceResult = surface === 'cli'
+              ? await runCliTask(task, fixture.projectPath, godotPath)
+              : await runMcpTask(task, mcp, fixture.projectPath);
+            const assertionFailures = assertTask(task, fixture.projectPath, surfaceResult);
+            runResults.push({
+              taskId: task.id,
+              family: task.family,
+              label: task.label,
+              surface,
+              iteration,
+              projectPath: fixture.projectPath,
+              ok: surfaceResult.ok && assertionFailures.length === 0,
+              durationMs: surfaceResult.durationMs,
+              invocationCount: surfaceResult.invocationCount,
+              interfaceTokenEstimate: surfaceResult.interfaceTokenEstimate,
+              stdout: surfaceResult.stdout,
+              stderr: surfaceResult.stderr,
+              assertionFailures,
+            });
+          } finally {
+            if (!args.keepFixtures) {
+              rmSync(fixture.tempRoot, { recursive: true, force: true });
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    await mcp.close();
+  }
+
+  const grouped = selectedTaskIds.map((taskId) => {
+    const task = matrix.tasks.find((entry) => entry.id === taskId);
+    const taskRuns = runResults.filter((entry) => entry.taskId === taskId);
+    return {
+      taskId,
+      family: task?.family,
+      label: task?.label,
+      summary: summarize(taskRuns),
+      runs: taskRuns,
+    };
+  });
+
+  const report = {
+    benchmark: 'gopeak-cli-vs-mcp',
+    sourceProjectPath,
+    mcpProfile: matrix.baseline?.mcpProfile || 'compact',
+    iterations,
+    generatedAt: new Date().toISOString(),
+    tasks: grouped,
+  };
+
+  if (args.output) {
+    writeFileSync(resolve(args.output), JSON.stringify(report, null, 2));
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/benchmark/cli-vs-mcp.matrix.json
+++ b/scripts/benchmark/cli-vs-mcp.matrix.json
@@ -1,0 +1,116 @@
+{
+  "version": 1,
+  "baseline": {
+    "mcpProfile": "compact",
+    "notes": [
+      "Compact MCP is the primary baseline.",
+      "Validation task preserves MCP compatibility checks by activating the import_export dynamic group before validate_project."
+    ]
+  },
+  "tasks": [
+    {
+      "id": "scene_create",
+      "family": "scene_script_mutation",
+      "label": "Create scene",
+      "setup": { "kind": "fresh_copy" },
+      "cli": {
+        "command": "scene-create",
+        "args": {
+          "scenePath": "scenes/BenchmarkScene.tscn",
+          "rootNodeType": "Node2D"
+        }
+      },
+      "mcp": {
+        "calls": [
+          {
+            "tool": "scene.create",
+            "args": {
+              "scenePath": "scenes/BenchmarkScene.tscn",
+              "rootNodeType": "Node2D"
+            }
+          }
+        ]
+      },
+      "assertions": [
+        { "type": "path_exists", "path": "scenes/BenchmarkScene.tscn" }
+      ]
+    },
+    {
+      "id": "script_modify",
+      "family": "scene_script_mutation",
+      "label": "Modify script",
+      "setup": { "kind": "fresh_copy" },
+      "cli": {
+        "command": "script-modify",
+        "args": {
+          "scriptPath": "scripts/player.gd",
+          "modifications": [
+            {
+              "type": "add_function",
+              "name": "benchmark_marker",
+              "params": "",
+              "returnType": "void",
+              "body": "\tprint(\"benchmark-marker\")",
+              "position": "end"
+            }
+          ]
+        }
+      },
+      "mcp": {
+        "calls": [
+          {
+            "tool": "script.modify",
+            "args": {
+              "scriptPath": "scripts/player.gd",
+              "modifications": [
+                {
+                  "type": "add_function",
+                  "name": "benchmark_marker",
+                  "params": "",
+                  "returnType": "void",
+                  "body": "\tprint(\"benchmark-marker\")",
+                  "position": "end"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "assertions": [
+        { "type": "file_contains", "path": "scripts/player.gd", "needle": "func benchmark_marker() -> void:" }
+      ]
+    },
+    {
+      "id": "validate_project",
+      "family": "build_validation",
+      "label": "Validate project",
+      "setup": { "kind": "fresh_copy" },
+      "cli": {
+        "command": "validate-project",
+        "args": {
+          "includeSuggestions": true
+        }
+      },
+      "mcp": {
+        "calls": [
+          {
+            "tool": "tool.groups",
+            "args": {
+              "action": "activate",
+              "group": "import_export"
+            }
+          },
+          {
+            "tool": "validate_project",
+            "args": {
+              "includeSuggestions": true
+            }
+          }
+        ]
+      },
+      "assertions": [
+        { "type": "stdout_nonempty" }
+      ]
+    }
+  ]
+}

--- a/scripts/benchmark/gopeak-cli-prototype.mjs
+++ b/scripts/benchmark/gopeak-cli-prototype.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { execFile, exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const execAsync = promisify(execCallback);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const operationsScriptPath = join(repoRoot, 'src', 'scripts', 'godot_operations.gd');
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      result._.push(token);
+      continue;
+    }
+
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      result[key] = true;
+      continue;
+    }
+
+    result[key] = next;
+    i += 1;
+  }
+  return result;
+}
+
+function estimateTokens(value) {
+  return Math.max(1, Math.ceil(String(value).length / 4));
+}
+
+function parseJsonArgument(value, fallback) {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`Invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function runGodotOperation(operation, params, projectPath, godotPath) {
+  const payload = JSON.stringify(params ?? {});
+  const commandArgs = [
+    '--headless',
+    '--path',
+    projectPath,
+    '--script',
+    operationsScriptPath,
+    operation,
+    payload,
+  ];
+
+  return await new Promise((resolvePromise, rejectPromise) => {
+    execFile(godotPath, commandArgs, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        resolvePromise({ ok: false, stdout, stderr, error: error.message, commandArgs });
+        return;
+      }
+      resolvePromise({ ok: true, stdout, stderr, commandArgs });
+    });
+  });
+}
+
+async function validateProject(projectPath, godotPath, preset = '', includeSuggestions = true) {
+  return await runGodotOperation(
+    'validate_project',
+    { preset, include_suggestions: includeSuggestions },
+    projectPath,
+    godotPath,
+  );
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  const [command] = parsed._;
+  const godotPath = parsed.godotPath || process.env.GODOT_PATH || 'godot';
+
+  if (!command || parsed.help) {
+    console.log([
+      'GoPeak CLI Prototype (benchmark-only)',
+      '',
+      'Commands:',
+      '  scene-create      --projectPath <dir> --scenePath <res> [--rootNodeType Node2D]',
+      '  script-modify     --projectPath <dir> --scriptPath <res> --modifications <json>',
+      '  validate-project  --projectPath <dir> [--preset <name>] [--includeSuggestions true|false]',
+      '',
+      'Output is JSON by default.',
+    ].join('\n'));
+    return;
+  }
+
+  const startedAt = Date.now();
+  let operationName = command;
+  let execution;
+
+  switch (command) {
+    case 'scene-create': {
+      if (!parsed.projectPath || !parsed.scenePath) {
+        throw new Error('scene-create requires --projectPath and --scenePath');
+      }
+      operationName = 'create_scene';
+      execution = await runGodotOperation(
+        'create_scene',
+        { scene_path: parsed.scenePath, root_node_type: parsed.rootNodeType || 'Node2D' },
+        parsed.projectPath,
+        godotPath,
+      );
+      break;
+    }
+    case 'script-modify': {
+      if (!parsed.projectPath || !parsed.scriptPath || !parsed.modifications) {
+        throw new Error('script-modify requires --projectPath, --scriptPath, and --modifications');
+      }
+      operationName = 'modify_script';
+      execution = await runGodotOperation(
+        'modify_script',
+        {
+          script_path: parsed.scriptPath,
+          modifications: parseJsonArgument(parsed.modifications, []),
+        },
+        parsed.projectPath,
+        godotPath,
+      );
+      break;
+    }
+    case 'validate-project': {
+      if (!parsed.projectPath) {
+        throw new Error('validate-project requires --projectPath');
+      }
+      operationName = 'validate_project';
+      execution = await validateProject(
+        parsed.projectPath,
+        godotPath,
+        typeof parsed.preset === 'string' ? parsed.preset : '',
+        parsed.includeSuggestions !== 'false',
+      );
+      break;
+    }
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+
+  const result = {
+    ok: Boolean(execution?.ok),
+    surface: 'cli-prototype',
+    command,
+    operationName,
+    invocationCount: 1,
+    interfaceTokenEstimate: estimateTokens(process.argv.slice(2).join(' ')),
+    durationMs: Date.now() - startedAt,
+    stdout: execution?.stdout?.trim() ?? '',
+    stderr: execution?.stderr?.trim() ?? '',
+    error: execution?.error ?? null,
+    commandArgs: execution?.commandArgs ?? [],
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(JSON.stringify({
+    ok: false,
+    surface: 'cli-prototype',
+    error: error instanceof Error ? error.message : String(error),
+  }, null, 2));
+  process.exit(1);
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -14,11 +14,13 @@
  */
 
 import { getLocalVersion } from './cli/utils.js';
+import { runPrototypeCommand } from './cli/prototype.js';
+import { runBenchmarkCommand } from './cli/benchmark.js';
 
 const args = process.argv.slice(2);
 const command = args[0];
 
-const CLI_COMMANDS = ['setup', 'check', 'star', 'notify', 'uninstall', 'version', 'help', '--version', '-v', '--help', '-h'];
+const CLI_COMMANDS = ['setup', 'check', 'star', 'notify', 'uninstall', 'version', 'help', 'script', 'editor', 'debug', 'project', 'benchmark', '--version', '-v', '--help', '-h'];
 
 async function main(): Promise<void> {
   // If no args or not a CLI command → start MCP server (original behavior)
@@ -54,6 +56,19 @@ async function main(): Promise<void> {
       await uninstallHooks();
       break;
     }
+    case 'script':
+    case 'editor':
+    case 'debug':
+    case 'project': {
+      const ok = await runPrototypeCommand(args);
+      process.exitCode = ok ? 0 : 1;
+      break;
+    }
+    case 'benchmark': {
+      const ok = await runBenchmarkCommand(args.slice(1));
+      process.exitCode = ok ? 0 : 1;
+      break;
+    }
     case 'version':
     case '--version':
     case '-v': {
@@ -82,6 +97,12 @@ Usage:
   gopeak check --quiet  Print only if update available
   gopeak star           Star GoPeak on GitHub
   gopeak uninstall      Remove shell hooks
+  gopeak script ...     Prototype script-mutation commands (compact MCP-backed)
+  gopeak editor ...     Prototype run/stop commands (compact MCP-backed)
+  gopeak debug output   Prototype debug-log retrieval (compact MCP-backed)
+  gopeak project export Prototype export/build command (compact MCP-backed)
+  gopeak project validate Prototype validation command (compact MCP-backed)
+  gopeak benchmark ...  Compare prototype CLI vs compact MCP and normalize evidence
   gopeak version        Show current version
   gopeak help           Show this help
 

--- a/src/cli/benchmark.ts
+++ b/src/cli/benchmark.ts
@@ -1,0 +1,337 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
+import { spawn } from 'child_process';
+import { callCompactTool, extractTextContent, listCompactTools } from './mcp-client.js';
+
+interface CliTaskSpec {
+  command: string[];
+  interfaceText?: string;
+}
+
+interface McpTaskSpec {
+  tool: string;
+  args?: Record<string, unknown>;
+}
+
+interface BenchmarkTaskSpec {
+  id: string;
+  family: string;
+  description?: string;
+  cli?: CliTaskSpec;
+  mcp?: McpTaskSpec;
+}
+
+interface BenchmarkSpec {
+  name?: string;
+  repetitions?: number;
+  tasks: BenchmarkTaskSpec[];
+}
+
+interface RunRecord {
+  taskId: string;
+  family: string;
+  surface: 'cli' | 'mcp';
+  success: boolean;
+  durationMs: number;
+  invocationCount: number;
+  estimatedInputTokens: number;
+  startedAt: string;
+  finishedAt: string;
+  summary: string;
+  command?: string[];
+  tool?: string;
+  stderr?: string;
+}
+
+
+function resolvePlaceholders(value: unknown, replacements: Record<string, string>): unknown {
+  if (typeof value === 'string') {
+    let resolved = value;
+    for (const [key, replacement] of Object.entries(replacements)) {
+      resolved = resolved.replaceAll(`{${key}}`, replacement);
+    }
+    return resolved;
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => resolvePlaceholders(entry, replacements));
+  }
+
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, entry]) => [key, resolvePlaceholders(entry, replacements)])
+    );
+  }
+
+  return value;
+}
+
+function estimateTokens(text: string): number {
+  return Math.max(1, Math.ceil(text.trim().length / 4));
+}
+
+function median(values: number[]): number {
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length === 0) {
+    return 0;
+  }
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+function parseArgs(args: string[]): { positionals: string[]; flags: Record<string, string | boolean> } {
+  const positionals: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (!current.startsWith('--')) {
+      positionals.push(current);
+      continue;
+    }
+
+    const stripped = current.slice(2);
+    const [key, inline] = stripped.split('=', 2);
+    if (inline !== undefined) {
+      flags[key] = inline;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (!next || next.startsWith('--')) {
+      flags[key] = true;
+      continue;
+    }
+
+    flags[key] = next;
+    index += 1;
+  }
+
+  return { positionals, flags };
+}
+
+function requireString(flags: Record<string, string | boolean>, key: string): string {
+  const value = flags[key];
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  throw new Error(`Missing --${key}`);
+}
+
+function printBenchmarkHelp(): void {
+  console.log(`
+Benchmark commands:
+  gopeak benchmark compare --spec <path> [--out <path>] [--runs <n>]
+  gopeak benchmark compat
+
+Spec schema:
+  {
+    "name": "gopeak-cli-vs-mcp",
+    "repetitions": 3,
+    "tasks": [
+      {
+        "id": "script-create",
+        "family": "script-mutation",
+        "cli": { "command": ["script", "create", "--project-path", "/abs/project", "--script-path", "scripts/foo.gd"] },
+        "mcp": { "tool": "script.create", "args": { "projectPath": "/abs/project", "scriptPath": "scripts/foo.gd" } }
+      }
+    ]
+  }
+`.trim());
+}
+
+async function runCliTask(task: BenchmarkTaskSpec, runNumber: number): Promise<RunRecord> {
+  if (!task.cli) {
+    throw new Error(`Task ${task.id} is missing cli spec`);
+  }
+
+  const started = new Date();
+  const resolvedCli = resolvePlaceholders(task.cli, { surface: 'cli', run: String(runNumber) }) as CliTaskSpec;
+  const commandText = resolvedCli.interfaceText || resolvedCli.command.join(' ');
+  const cliPath = join(import.meta.dirname, '..', 'cli.js');
+
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [cliPath, ...resolvedCli.command], {
+      cwd: join(import.meta.dirname, '..'),
+      env: process.env,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString();
+    });
+
+    child.stderr.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString();
+    });
+
+    child.on('close', (code) => {
+      const finished = new Date();
+      resolve({
+        taskId: task.id,
+        family: task.family,
+        surface: 'cli',
+        success: code === 0,
+        durationMs: finished.getTime() - started.getTime(),
+        invocationCount: 1,
+        estimatedInputTokens: estimateTokens(commandText),
+        startedAt: started.toISOString(),
+        finishedAt: finished.toISOString(),
+        summary: (stdout || stderr).trim().slice(0, 500),
+        command: resolvedCli.command,
+        stderr: stderr.trim() || undefined,
+      });
+    });
+  });
+}
+
+async function runMcpTask(task: BenchmarkTaskSpec, schemaTokenCache: Map<string, number>, runNumber: number): Promise<RunRecord> {
+  if (!task.mcp) {
+    throw new Error(`Task ${task.id} is missing mcp spec`);
+  }
+
+  const resolvedMcp = resolvePlaceholders(task.mcp, { surface: 'mcp', run: String(runNumber) }) as McpTaskSpec;
+  const started = new Date();
+  const result = await callCompactTool(resolvedMcp.tool, resolvedMcp.args || {});
+  const finished = new Date();
+  const schemaTokens = schemaTokenCache.get(resolvedMcp.tool) || 0;
+  const argTokens = estimateTokens(JSON.stringify(resolvedMcp.args || {}));
+
+  return {
+    taskId: task.id,
+    family: task.family,
+    surface: 'mcp',
+    success: !('isError' in result && result.isError),
+    durationMs: finished.getTime() - started.getTime(),
+    invocationCount: 1,
+    estimatedInputTokens: schemaTokens + argTokens,
+    startedAt: started.toISOString(),
+    finishedAt: finished.toISOString(),
+    summary: extractTextContent(result).slice(0, 500),
+    tool: resolvedMcp.tool,
+  };
+}
+
+async function buildSchemaTokenCache(): Promise<Map<string, number>> {
+  const tools = await listCompactTools();
+  const cache = new Map<string, number>();
+  for (const tool of tools) {
+    cache.set(tool.name, estimateTokens(JSON.stringify({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: tool.inputSchema,
+    })));
+  }
+  return cache;
+}
+
+async function runCompatibilityChecks(): Promise<void> {
+  const tools = await listCompactTools();
+  const compactNames = new Set(tools.map((tool) => tool.name));
+  const required = ['tool.catalog', 'script.create', 'script.modify', 'editor.run', 'editor.debug_output', 'export.run'];
+  const missing = required.filter((name) => !compactNames.has(name));
+  if (missing.length > 0) {
+    throw new Error(`Missing compact tools: ${missing.join(', ')}`);
+  }
+
+  const catalogResult = await callCompactTool('tool.catalog', { query: 'script', limit: 5 });
+  if ('isError' in catalogResult && catalogResult.isError) {
+    throw new Error(`tool.catalog compatibility check failed: ${extractTextContent(catalogResult)}`);
+  }
+
+  console.log('Compatibility checks passed: compact tool aliases present and tool.catalog callable.');
+}
+
+async function runCompare(flags: Record<string, string | boolean>): Promise<boolean> {
+  const specPath = requireString(flags, 'spec');
+  const outPath = typeof flags.out === 'string' ? flags.out : 'artifacts/gopeak-cli-vs-mcp-benchmark.json';
+  const file = readFileSync(specPath, 'utf8');
+  const spec = JSON.parse(file) as BenchmarkSpec;
+  const repetitions = typeof flags.runs === 'string' ? Number(flags.runs) : spec.repetitions || 3;
+  if (!Number.isFinite(repetitions) || repetitions < 1) {
+    throw new Error(`Invalid repetition count: ${repetitions}`);
+  }
+
+  await runCompatibilityChecks();
+  const schemaTokenCache = await buildSchemaTokenCache();
+  const runs: RunRecord[] = [];
+
+  for (const task of spec.tasks) {
+    for (let index = 0; index < repetitions; index += 1) {
+      if (task.cli) {
+        runs.push(await runCliTask(task, index + 1));
+      }
+      if (task.mcp) {
+        runs.push(await runMcpTask(task, schemaTokenCache, index + 1));
+      }
+    }
+  }
+
+  const summary = Object.values(
+    runs.reduce<Record<string, { taskId: string; family: string; surface: 'cli' | 'mcp'; durations: number[]; tokens: number[]; successes: number }>>((acc, run) => {
+      const key = `${run.taskId}:${run.surface}`;
+      if (!acc[key]) {
+        acc[key] = {
+          taskId: run.taskId,
+          family: run.family,
+          surface: run.surface,
+          durations: [],
+          tokens: [],
+          successes: 0,
+        };
+      }
+      acc[key].durations.push(run.durationMs);
+      acc[key].tokens.push(run.estimatedInputTokens);
+      acc[key].successes += run.success ? 1 : 0;
+      return acc;
+    }, {})
+  ).map((entry) => ({
+    taskId: entry.taskId,
+    family: entry.family,
+    surface: entry.surface,
+    medianDurationMs: median(entry.durations),
+    medianEstimatedInputTokens: median(entry.tokens),
+    successRate: entry.successes / entry.durations.length,
+    samples: entry.durations.length,
+  }));
+
+  mkdirSync(dirname(outPath), { recursive: true });
+  writeFileSync(outPath, JSON.stringify({
+    name: spec.name || 'gopeak-cli-vs-mcp-benchmark',
+    generatedAt: new Date().toISOString(),
+    repetitions,
+    runs,
+    summary,
+  }, null, 2));
+
+  console.log(`Benchmark results written to ${outPath}`);
+  console.log(JSON.stringify(summary, null, 2));
+  return true;
+}
+
+export async function runBenchmarkCommand(args: string[]): Promise<boolean> {
+  const parsed = parseArgs(args);
+  const [subcommand] = parsed.positionals;
+
+  if (!subcommand || subcommand === 'help' || parsed.flags.help === true) {
+    printBenchmarkHelp();
+    return true;
+  }
+
+  switch (subcommand) {
+    case 'compat':
+      await runCompatibilityChecks();
+      return true;
+    case 'compare':
+      return runCompare(parsed.flags);
+    default:
+      printBenchmarkHelp();
+      throw new Error(`Unknown benchmark command: ${subcommand}`);
+  }
+}

--- a/src/cli/mcp-client.ts
+++ b/src/cli/mcp-client.ts
@@ -1,0 +1,64 @@
+import { join } from 'path';
+import process from 'process';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+
+export type CompactToolResult = Awaited<ReturnType<Client['callTool']>>;
+export type CompactToolDefinition = Awaited<ReturnType<Client['listTools']>>['tools'][number];
+
+function getBuildRoot(): string {
+  return join(import.meta.dirname, '..');
+}
+
+async function withClient<T>(run: (client: Client) => Promise<T>): Promise<T> {
+  const root = getBuildRoot();
+  const transport = new StdioClientTransport({
+    command: process.execPath,
+    args: [join(root, 'index.js')],
+    cwd: root,
+    env: {
+      ...process.env,
+      GOPEAK_TOOL_PROFILE: process.env.GOPEAK_TOOL_PROFILE || 'compact',
+    },
+    stderr: 'pipe',
+  });
+
+  const client = new Client({
+    name: 'gopeak-cli-prototype',
+    version: '0.0.0',
+  });
+
+  await client.connect(transport);
+  try {
+    return await run(client);
+  } finally {
+    await transport.close();
+  }
+}
+
+export async function callCompactTool(name: string, args: Record<string, unknown> = {}): Promise<CompactToolResult> {
+  return withClient((client) => client.callTool({ name, arguments: args }));
+}
+
+export async function listCompactTools(): Promise<CompactToolDefinition[]> {
+  return withClient(async (client) => {
+    const result = await client.listTools();
+    return result.tools;
+  });
+}
+
+export function extractTextContent(result: CompactToolResult): string {
+  if ('toolResult' in result) {
+    return JSON.stringify(result.toolResult, null, 2);
+  }
+
+  const textParts = result.content
+    .filter((entry): entry is Extract<typeof entry, { type: 'text' }> => entry.type === 'text')
+    .map((entry) => entry.text);
+
+  if (textParts.length > 0) {
+    return textParts.join('\n');
+  }
+
+  return JSON.stringify(result, null, 2);
+}

--- a/src/cli/prototype.ts
+++ b/src/cli/prototype.ts
@@ -1,0 +1,173 @@
+import { callCompactTool, extractTextContent } from './mcp-client.js';
+
+type ParsedArgs = {
+  positionals: string[];
+  flags: Record<string, string | boolean>;
+};
+
+function toCamelCase(input: string): string {
+  return input.replace(/-([a-z])/g, (_, letter: string) => letter.toUpperCase());
+}
+
+function parseArgs(args: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const flags: Record<string, string | boolean> = {};
+
+  for (let index = 0; index < args.length; index += 1) {
+    const current = args[index];
+    if (!current.startsWith('--')) {
+      positionals.push(current);
+      continue;
+    }
+
+    const trimmed = current.slice(2);
+    const [rawKey, inlineValue] = trimmed.split('=', 2);
+    const key = toCamelCase(rawKey);
+
+    if (inlineValue !== undefined) {
+      flags[key] = inlineValue;
+      continue;
+    }
+
+    const next = args[index + 1];
+    if (!next || next.startsWith('--')) {
+      flags[key] = true;
+      continue;
+    }
+
+    flags[key] = next;
+    index += 1;
+  }
+
+  return { positionals, flags };
+}
+
+function requireString(flags: Record<string, string | boolean>, key: string, help: string): string {
+  const value = flags[key];
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+  throw new Error(`Missing --${key.replace(/[A-Z]/g, (letter) => `-${letter.toLowerCase()}`)}\n\n${help}`);
+}
+
+function parseJsonFlag<T>(flags: Record<string, string | boolean>, key: string, fallback: T): T {
+  const value = flags[key];
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  try {
+    return JSON.parse(value) as T;
+  } catch (error) {
+    throw new Error(`Invalid JSON for --${key}: ${(error as Error).message}`);
+  }
+}
+
+function printPrototypeHelp(): void {
+  console.log(`
+Prototype task commands (compact MCP-backed):
+  gopeak script create --project-path <abs> --script-path <rel> [--extends Node] [--class-name Foo] [--template component] [--content '...']
+  gopeak script modify --project-path <abs> --script-path <rel> --modifications '[{"type":"add_function","name":"hello","body":"pass"}]'
+  gopeak editor run --project-path <abs> [--scene <rel-scene>]
+  gopeak debug output --reason <text>
+  gopeak editor stop --reason <text>
+  gopeak project export --project-path <abs> --preset <name> --output-path <abs-or-rel> [--debug]
+  gopeak project validate --project-path <abs> [--preset <name>] [--include-suggestions false]
+
+Notes:
+  - These commands intentionally cover the benchmark task families only.
+  - They call the compact MCP aliases internally so behavior stays aligned with the MCP baseline.
+`.trim());
+}
+
+export async function runPrototypeCommand(args: string[]): Promise<boolean> {
+  const parsed = parseArgs(args);
+  const [group, action] = parsed.positionals;
+
+  if (!group || group === 'help' || parsed.flags.help === true) {
+    printPrototypeHelp();
+    return true;
+  }
+
+  let toolName: string;
+  let toolArgs: Record<string, unknown>;
+
+  switch (`${group}:${action ?? ''}`) {
+    case 'script:create':
+      toolName = 'script.create';
+      toolArgs = {
+        projectPath: requireString(parsed.flags, 'projectPath', 'Required for script create'),
+        scriptPath: requireString(parsed.flags, 'scriptPath', 'Required for script create'),
+        extends: typeof parsed.flags.extends === 'string' ? parsed.flags.extends : 'Node',
+        className: typeof parsed.flags.className === 'string' ? parsed.flags.className : undefined,
+        template: typeof parsed.flags.template === 'string' ? parsed.flags.template : undefined,
+        content: typeof parsed.flags.content === 'string' ? parsed.flags.content : undefined,
+      };
+      break;
+    case 'script:modify':
+      toolName = 'script.modify';
+      toolArgs = {
+        projectPath: requireString(parsed.flags, 'projectPath', 'Required for script modify'),
+        scriptPath: requireString(parsed.flags, 'scriptPath', 'Required for script modify'),
+        modifications: parseJsonFlag(parsed.flags, 'modifications', []),
+      };
+      break;
+    case 'editor:run':
+      toolName = 'editor.run';
+      toolArgs = {
+        projectPath: requireString(parsed.flags, 'projectPath', 'Required for editor run'),
+        scene: typeof parsed.flags.scene === 'string' ? parsed.flags.scene : undefined,
+      };
+      break;
+    case 'editor:stop':
+      toolName = 'editor.stop';
+      toolArgs = {
+        reason: typeof parsed.flags.reason === 'string' ? parsed.flags.reason : 'CLI prototype stop',
+      };
+      break;
+    case 'debug:output':
+      toolName = 'editor.debug_output';
+      toolArgs = {
+        reason: requireString(parsed.flags, 'reason', 'Required for debug output'),
+      };
+      break;
+    case 'project:export':
+      toolName = 'export.run';
+      toolArgs = {
+        projectPath: requireString(parsed.flags, 'projectPath', 'Required for project export'),
+        preset: requireString(parsed.flags, 'preset', 'Required for project export'),
+        outputPath: requireString(parsed.flags, 'outputPath', 'Required for project export'),
+        debug: parsed.flags.debug === true,
+      };
+      break;
+    case 'project:validate': {
+      const projectPath = requireString(parsed.flags, 'projectPath', 'Required for project validate');
+      const groupResult = await callCompactTool('tool.groups', { action: 'activate', group: 'import_export' });
+      if ('isError' in groupResult && groupResult.isError) {
+        console.error(extractTextContent(groupResult));
+        return false;
+      }
+      toolName = 'validate_project';
+      toolArgs = {
+        projectPath,
+        preset: typeof parsed.flags.preset === 'string' ? parsed.flags.preset : '',
+        includeSuggestions: parsed.flags.includeSuggestions !== 'false',
+      };
+      break;
+    }
+    default:
+      printPrototypeHelp();
+      throw new Error(`Unknown prototype command: ${group}${action ? ` ${action}` : ''}`);
+  }
+
+  const result = await callCompactTool(toolName, toolArgs);
+  const text = extractTextContent(result);
+
+  if ('isError' in result && result.isError) {
+    console.error(text);
+    return false;
+  }
+
+  console.log(text);
+  return true;
+}

--- a/test-benchmark-cli-vs-mcp.mjs
+++ b/test-benchmark-cli-vs-mcp.mjs
@@ -1,0 +1,130 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+const REPO = '/home/yun/Gopeak-godot-mcp';
+const CLI = join(REPO, 'build/cli.js');
+const FIXTURE = '/home/yun/gopeak-demo';
+const ARTIFACT_DIR = '/home/yun/.omx/artifacts/gopeak-cli-vs-mcp/worker-2';
+
+async function runCli(args, extraEnv = {}) {
+  const { stdout, stderr } = await execFile(process.execPath, [CLI, ...args], {
+    cwd: REPO,
+    env: { ...process.env, ...extraEnv },
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  return { stdout, stderr };
+}
+
+async function main() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'gopeak-benchmark-worker-2-'));
+  const projectCopy = join(tempRoot, 'gopeak-demo');
+  const specPath = join(tempRoot, 'benchmark-spec.json');
+  const outPath = join(tempRoot, 'benchmark-report.json');
+
+  try {
+    await execFile('cp', ['-R', FIXTURE, projectCopy], { cwd: REPO, maxBuffer: 1024 * 1024 * 20 });
+
+    const help = await runCli(['help']);
+    assert.match(help.stdout, /gopeak benchmark \.\.\./);
+
+    const scriptHelp = await runCli(['script', '--help']);
+    assert.match(scriptHelp.stdout, /gopeak script create/);
+    assert.match(scriptHelp.stdout, /gopeak project export/);
+
+    const compat = await runCli(['benchmark', 'compat'], {
+      GOPEAK_TOOL_PROFILE: 'compact',
+      GOPEAK_TOOLS_PAGE_SIZE: '9999',
+    });
+    assert.match(compat.stdout, /Compatibility checks passed/);
+
+    const spec = {
+      name: 'worker-2-benchmark-smoke',
+      repetitions: 1,
+      tasks: [
+        {
+          id: 'script-create',
+          family: 'script-mutation',
+          cli: {
+            command: [
+              'script',
+              'create',
+              '--project-path', projectCopy,
+              '--script-path', 'scripts/worker2_cli_create.gd',
+              '--extends', 'Node',
+            ],
+          },
+          mcp: {
+            tool: 'script.create',
+            args: {
+              projectPath: projectCopy,
+              scriptPath: 'scripts/worker2_mcp_create.gd',
+              extends: 'Node',
+            },
+          },
+        },
+        {
+          id: 'script-modify',
+          family: 'script-mutation',
+          cli: {
+            command: [
+              'script',
+              'modify',
+              '--project-path', projectCopy,
+              '--script-path', 'scripts/worker2_cli_create.gd',
+              '--modifications', '[{"type":"add_function","name":"worker_two_cli","body":"pass"}]',
+            ],
+          },
+          mcp: {
+            tool: 'script.modify',
+            args: {
+              projectPath: projectCopy,
+              scriptPath: 'scripts/worker2_mcp_create.gd',
+              modifications: [
+                { type: 'add_function', name: 'worker_two_mcp', body: 'pass' },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    await writeFile(specPath, JSON.stringify(spec, null, 2));
+
+    const compare = await runCli(['benchmark', 'compare', '--spec', specPath, '--out', outPath, '--runs', '1'], {
+      GOPEAK_TOOL_PROFILE: 'compact',
+      GOPEAK_TOOLS_PAGE_SIZE: '9999',
+    });
+    assert.match(compare.stdout, /Benchmark results written to/);
+
+    const report = JSON.parse(await readFile(outPath, 'utf8'));
+    assert.equal(report.runs.length, 4, `expected 4 run records, got ${report.runs.length}`);
+    assert(report.runs.every((run) => run.success === true), 'expected all benchmark runs to succeed');
+
+    await mkdir(ARTIFACT_DIR, { recursive: true });
+    await writeFile(join(ARTIFACT_DIR, 'benchmark-smoke-spec.json'), JSON.stringify(spec, null, 2));
+    await writeFile(join(ARTIFACT_DIR, 'benchmark-smoke-report.json'), JSON.stringify(report, null, 2));
+
+    const cliScript = await readFile(join(projectCopy, 'scripts/worker2_cli_create.gd'), 'utf8');
+    const mcpScript = await readFile(join(projectCopy, 'scripts/worker2_mcp_create.gd'), 'utf8');
+    assert.match(cliScript, /func worker_two_cli\(\)/);
+    assert.match(mcpScript, /func worker_two_mcp\(\)/);
+
+    console.log('PASS test-benchmark-cli-vs-mcp');
+    console.log(`report=${outPath}`);
+    console.log(`project_copy=${projectCopy}`);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error('FAIL test-benchmark-cli-vs-mcp');
+  console.error(error?.stack || error?.message || String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR packages the current GoPeak CLI-vs-MCP validation work for review against `dev`.

It combines three kinds of changes in one reviewable branch:
- documentation that explains the benchmark scope, guardrails, and current recommendation,
- a narrow CLI prototype for benchmark-oriented command families,
- benchmark specs/helpers/tests plus evidence artifacts used to interpret the result.

## Why

The validation work now has concrete repo-local evidence, but the result is mixed rather than a blanket CLI win:
- `script_modify`: **MCP wins** on the current comparable shared-path benchmark.
- `validate_project`: **CLI wins** on the current comparable shared-path benchmark.
- `scene_create`: **non-comparable** in the current compact/headless setup because the MCP path depends on the editor/plugin-backed bridge.

That means this PR should be reviewed as a **benchmark-and-positioning package**, not as proof that GoPeak should replace MCP with CLI.

## What changed

### 1. Validation documentation
This branch adds and links a dedicated validation note:
- `docs/gopeak-cli-vs-mcp-validation.md`
- `docs/README.md`
- `README.md`

The validation note documents:
- the compact MCP baseline,
- shared-core vs mixed-path vs MCP-coupled families,
- fairness guardrails for interpreting benchmark results,
- the current hybrid recommendation.

### 2. CLI prototype surface
This branch extends the public `gopeak` CLI entry with a narrow benchmark-oriented prototype surface:
- `gopeak script ...`
- `gopeak editor ...`
- `gopeak debug output`
- `gopeak project ...`
- `gopeak benchmark ...`

Relevant implementation files:
- `src/cli.ts`
- `src/cli/prototype.ts`
- `src/cli/mcp-client.ts`
- `src/cli/benchmark.ts`

The intent is to evaluate benchmarkable command families without changing the repo's current MCP-first default startup path.

### 3. Benchmark harness + evidence
This branch also adds:
- benchmark helper scripts under `scripts/benchmark/`,
- benchmark definitions/specs under `benchmarks/`,
- a focused smoke test in `test-benchmark-cli-vs-mcp.mjs`,
- repo-local evidence artifacts under `artifacts/`.

These files support reproducible CLI-vs-MCP comparison using compact MCP as the baseline.

## Current evidence snapshot

Baseline: **compact MCP profile**.

| Family | Comparable? | Current result | Interpretation |
| --- | --- | --- | --- |
| `scene_create` | No | non-comparable | MCP path requires editor/plugin bridge in this setup |
| `script_modify` | Yes | MCP wins | shared-path benchmark currently favors MCP |
| `validate_project` | Yes | CLI wins | CLI currently reduces interface token cost while preserving success |

Current recommendation from the evidence: **keep a hybrid CLI + MCP direction**.

## Review focus

Please review this PR for four questions:

1. **Benchmark honesty**
   - Does the PR body and documentation clearly distinguish comparable vs non-comparable families?
   - Does it avoid overstating the meaning of current CLI wins?

2. **Prototype scope**
   - Is the CLI prototype still narrow and benchmark-oriented?
   - Are there any command families being presented as more mature than the evidence supports?

3. **Shared-path fairness**
   - Do the benchmarked families use a fair comparison seam where possible?
   - Are mixed-path/editor-coupled families labeled clearly enough?

4. **PR payload discipline**
   - Should raw `artifacts/*.json` remain in the branch, or should only scripts/specs/docs stay in the final commit set?

## Suggested follow-up issues

This PR should land alongside or immediately before companion issues covering:
1. benchmark harness hardening and reproducibility,
2. scene mutation comparability via plugin-backed editor coverage,
3. CLI prototype follow-up for benchmarkable command surfaces,
4. hybrid product/interface decision and documentation follow-up.

## Testing / verification referenced by this package

Commands used for the current validation lane:
- `npm run typecheck`
- `node test-benchmark-cli-vs-mcp.mjs`
- `npm run test:smoke`

Note: this PR package itself is documentation/output packaging, but it summarizes code/test results from the current branch state.

## Base branch

Target base branch: `dev`

## Published companion issues

- #21 — Harden the CLI-vs-MCP benchmark harness for reproducible evidence and publication-ready outputs
- #22 — Make `scene.create` benchmarkable via a plugin-backed editor lane or shared execution path
- #23 — Follow up on the CLI prototype for benchmarkable command surfaces
- #24 — Define and document the hybrid CLI + MCP product/interface direction after the current validation round
