### PR TITLE
feat(benchmark): add standalone CLI vs MCP benchmark scripts

### DIFF
--- a/benchmarks/gopeak-cli-vs-mcp.sample.json
+++ b/benchmarks/gopeak-cli-vs-mcp.sample.json
@@ -1,0 +1,131 @@
+{
+  "name": "gopeak-cli-vs-mcp-sample",
+  "repetitions": 3,
+  "tasks": [
+    {
+      "id": "script-create",
+      "family": "script-mutation",
+      "description": "Create a benchmark script in a real Godot project",
+      "cli": {
+        "command": [
+          "script",
+          "create",
+          "--project-path",
+          "/absolute/path/to/project",
+          "--script-path",
+          "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "--extends",
+          "Node"
+        ],
+        "interfaceText": "gopeak script create --project-path /absolute/path/to/project --script-path scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd --extends Node"
+      },
+      "mcp": {
+        "tool": "script.create",
+        "args": {
+          "projectPath": "/absolute/path/to/project",
+          "scriptPath": "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "extends": "Node"
+        }
+      }
+    },
+    {
+      "id": "script-modify",
+      "family": "script-mutation",
+      "description": "Append a deterministic function to the benchmark script",
+      "cli": {
+        "command": [
+          "script",
+          "modify",
+          "--project-path",
+          "/absolute/path/to/project",
+          "--script-path",
+          "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "--modifications",
+          "[{\"type\":\"add_function\",\"name\":\"benchmark_ping\",\"body\":\"return \\\"pong\\\"\",\"returnType\":\"String\"}]"
+        ],
+        "interfaceText": "gopeak script modify --project-path /absolute/path/to/project --script-path scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd --modifications '[...]'"
+      },
+      "mcp": {
+        "tool": "script.modify",
+        "args": {
+          "projectPath": "/absolute/path/to/project",
+          "scriptPath": "scripts/benchmark_cli_vs_mcp_{surface}_{run}.gd",
+          "modifications": [
+            {
+              "type": "add_function",
+              "name": "benchmark_ping",
+              "body": "return \"pong\"",
+              "returnType": "String"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "id": "editor-run",
+      "family": "run-debug",
+      "description": "Launch the project under debug",
+      "cli": {
+        "command": [
+          "editor",
+          "run",
+          "--project-path",
+          "/absolute/path/to/project"
+        ],
+        "interfaceText": "gopeak editor run --project-path /absolute/path/to/project"
+      },
+      "mcp": {
+        "tool": "editor.run",
+        "args": {
+          "projectPath": "/absolute/path/to/project"
+        }
+      }
+    },
+    {
+      "id": "debug-output",
+      "family": "run-debug",
+      "description": "Read captured debug output after running the project",
+      "cli": {
+        "command": [
+          "debug",
+          "output",
+          "--reason",
+          "benchmark"
+        ],
+        "interfaceText": "gopeak debug output --reason benchmark"
+      },
+      "mcp": {
+        "tool": "editor.debug_output",
+        "args": {
+          "reason": "benchmark"
+        }
+      }
+    },
+    {
+      "id": "project-export",
+      "family": "export-build",
+      "description": "Export the project using an existing preset",
+      "cli": {
+        "command": [
+          "project",
+          "export",
+          "--project-path",
+          "/absolute/path/to/project",
+          "--preset",
+          "Linux/X11",
+          "--output-path",
+          "/absolute/path/to/build/game.x86_64"
+        ],
+        "interfaceText": "gopeak project export --project-path /absolute/path/to/project --preset Linux/X11 --output-path /absolute/path/to/build/game.x86_64"
+      },
+      "mcp": {
+        "tool": "export.run",
+        "args": {
+          "projectPath": "/absolute/path/to/project",
+          "preset": "Linux/X11",
+          "outputPath": "/absolute/path/to/build/game.x86_64"
+        }
+      }
+    }
+  ]
+}

--- a/scripts/benchmark/cli-vs-mcp-benchmark.mjs
+++ b/scripts/benchmark/cli-vs-mcp-benchmark.mjs
@@ -1,0 +1,331 @@
+#!/usr/bin/env node
+import { spawn } from 'node:child_process';
+import { createInterface } from 'node:readline';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, resolve } from 'node:path';
+import { cpSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import process from 'node:process';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const prototypePath = join(__dirname, 'gopeak-cli-prototype.mjs');
+const matrixPath = join(__dirname, 'cli-vs-mcp.matrix.json');
+const buildServerPath = join(repoRoot, 'build', 'index.js');
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      result._.push(token);
+      continue;
+    }
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      result[key] = true;
+      continue;
+    }
+    result[key] = next;
+    i += 1;
+  }
+  return result;
+}
+
+function estimateTokens(value) {
+  return Math.max(1, Math.ceil(String(value).length / 4));
+}
+
+function median(values) {
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 0 ? (sorted[mid - 1] + sorted[mid]) / 2 : sorted[mid];
+}
+
+function ensureProjectCopy(sourceProjectPath, label) {
+  const tempRoot = mkdtempSync(join(tmpdir(), `gopeak-bench-${label}-`));
+  const target = join(tempRoot, 'project');
+  cpSync(sourceProjectPath, target, { recursive: true });
+  return { tempRoot, projectPath: target };
+}
+
+function assertTask(task, projectPath, surfaceResult) {
+  const failures = [];
+  for (const assertion of task.assertions || []) {
+    if (assertion.type === 'path_exists') {
+      const fullPath = join(projectPath, assertion.path);
+      if (!existsSync(fullPath)) {
+        failures.push(`missing path: ${assertion.path}`);
+      }
+    }
+    if (assertion.type === 'file_contains') {
+      const fullPath = join(projectPath, assertion.path);
+      const content = existsSync(fullPath) ? readFileSync(fullPath, 'utf8') : '';
+      if (!content.includes(assertion.needle)) {
+        failures.push(`missing content in ${assertion.path}: ${assertion.needle}`);
+      }
+    }
+    if (assertion.type === 'stdout_nonempty') {
+      if (!String(surfaceResult.stdout || '').trim()) {
+        failures.push('stdout was empty');
+      }
+    }
+  }
+  return failures;
+}
+
+class McpClient {
+  constructor(env) {
+    this.nextId = 1;
+    this.pending = new Map();
+    this.stderr = '';
+    this.process = spawn(process.execPath, [buildServerPath], {
+      cwd: repoRoot,
+      env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const rl = createInterface({ input: this.process.stdout });
+    rl.on('line', (line) => {
+      if (!line.trim()) return;
+      let payload;
+      try {
+        payload = JSON.parse(line);
+      } catch {
+        return;
+      }
+      if (typeof payload.id !== 'undefined' && this.pending.has(payload.id)) {
+        const { resolve: resolvePromise } = this.pending.get(payload.id);
+        this.pending.delete(payload.id);
+        resolvePromise(payload);
+      }
+    });
+    this.process.stderr.on('data', (chunk) => {
+      this.stderr += chunk.toString();
+    });
+  }
+
+  async request(method, params = {}, timeoutMs = 30000) {
+    const id = this.nextId += 1;
+    const payload = { jsonrpc: '2.0', id, method, params };
+    const serialized = JSON.stringify(payload);
+    const responsePromise = new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`Timeout waiting for ${method}`));
+      }, timeoutMs);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+      });
+    });
+    this.process.stdin.write(`${serialized}\n`);
+    return { response: await responsePromise, tokenEstimate: estimateTokens(serialized) };
+  }
+
+  async initialize() {
+    await this.request('initialize', {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'cli-vs-mcp-benchmark', version: '1.0.0' },
+    });
+    this.process.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' })}\n`);
+  }
+
+  async callTool(name, args) {
+    return await this.request('tools/call', { name, arguments: args });
+  }
+
+  async close() {
+    if (this.process.exitCode === null) {
+      this.process.stdin.end();
+      this.process.kill('SIGTERM');
+      await new Promise((resolve) => setTimeout(resolve, 250));
+    }
+  }
+}
+
+async function runCliTask(task, projectPath, godotPath) {
+  const args = [prototypePath, task.cli.command, '--projectPath', projectPath, '--godotPath', godotPath];
+  for (const [key, value] of Object.entries(task.cli.args || {})) {
+    args.push(`--${key}`);
+    args.push(typeof value === 'string' ? value : JSON.stringify(value));
+  }
+
+  const startedAt = Date.now();
+  const stdoutChunks = [];
+  const stderrChunks = [];
+  const child = spawn(process.execPath, args, { cwd: repoRoot, stdio: ['ignore', 'pipe', 'pipe'] });
+  child.stdout.on('data', (chunk) => stdoutChunks.push(chunk.toString()));
+  child.stderr.on('data', (chunk) => stderrChunks.push(chunk.toString()));
+
+  const exitCode = await new Promise((resolve) => child.on('close', resolve));
+  const stdout = stdoutChunks.join('').trim();
+  const stderr = stderrChunks.join('').trim();
+  let parsed = null;
+  try {
+    parsed = stdout ? JSON.parse(stdout) : null;
+  } catch {}
+
+  return {
+    ok: exitCode === 0 && Boolean(parsed?.ok),
+    exitCode,
+    stdout,
+    stderr,
+    parsed,
+    durationMs: Date.now() - startedAt,
+    invocationCount: parsed?.invocationCount ?? 1,
+    interfaceTokenEstimate: parsed?.interfaceTokenEstimate ?? estimateTokens(args.slice(1).join(' ')),
+  };
+}
+
+async function runMcpTask(task, mcp, projectPath) {
+  const startedAt = Date.now();
+  let invocationCount = 0;
+  let interfaceTokenEstimate = 0;
+  let lastText = '';
+  const responses = [];
+
+  for (const call of task.mcp.calls) {
+    const args = { ...(call.args || {}), projectPath };
+    const { response, tokenEstimate } = await mcp.callTool(call.tool, args);
+    invocationCount += 1;
+    interfaceTokenEstimate += tokenEstimate;
+    responses.push(response);
+    const text = response?.result?.content?.map((part) => part?.text || '').join('\n') || '';
+    lastText = text;
+    if (response?.error) {
+      return {
+        ok: false,
+        durationMs: Date.now() - startedAt,
+        invocationCount,
+        interfaceTokenEstimate,
+        stdout: lastText,
+        stderr: response.error.message || 'MCP error',
+        responses,
+      };
+    }
+  }
+
+  return {
+    ok: true,
+    durationMs: Date.now() - startedAt,
+    invocationCount,
+    interfaceTokenEstimate,
+    stdout: lastText,
+    stderr: '',
+    responses,
+  };
+}
+
+function summarize(results) {
+  const summary = {};
+  for (const surface of ['cli', 'mcp']) {
+    const surfaceRuns = results.filter((entry) => entry.surface === surface && entry.ok);
+    if (surfaceRuns.length === 0) {
+      summary[surface] = { okRuns: 0 };
+      continue;
+    }
+    summary[surface] = {
+      okRuns: surfaceRuns.length,
+      medianDurationMs: median(surfaceRuns.map((entry) => entry.durationMs)),
+      medianInvocationCount: median(surfaceRuns.map((entry) => entry.invocationCount)),
+      medianInterfaceTokenEstimate: median(surfaceRuns.map((entry) => entry.interfaceTokenEstimate)),
+    };
+  }
+  return summary;
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  const matrix = JSON.parse(readFileSync(matrixPath, 'utf8'));
+  const sourceProjectPath = resolve(args.projectPath || '/home/yun/gopeak-demo');
+  const selectedTaskIds = args.tasks ? String(args.tasks).split(',').map((item) => item.trim()) : matrix.tasks.map((task) => task.id);
+  const iterations = Math.max(1, Number.parseInt(args.iterations || '1', 10));
+  const godotPath = args.godotPath || process.env.GODOT_PATH || 'godot';
+
+  const mcp = new McpClient({
+    ...process.env,
+    GODOT_PATH: godotPath,
+    GOPEAK_TOOL_PROFILE: matrix.baseline?.mcpProfile || 'compact',
+  });
+  await mcp.initialize();
+
+  const runResults = [];
+  try {
+    for (const taskId of selectedTaskIds) {
+      const task = matrix.tasks.find((entry) => entry.id === taskId);
+      if (!task) {
+        throw new Error(`Unknown task id: ${taskId}`);
+      }
+
+      for (let iteration = 1; iteration <= iterations; iteration += 1) {
+        for (const surface of ['cli', 'mcp']) {
+          const fixture = ensureProjectCopy(sourceProjectPath, `${task.id}-${surface}-${iteration}`);
+          try {
+            const surfaceResult = surface === 'cli'
+              ? await runCliTask(task, fixture.projectPath, godotPath)
+              : await runMcpTask(task, mcp, fixture.projectPath);
+            const assertionFailures = assertTask(task, fixture.projectPath, surfaceResult);
+            runResults.push({
+              taskId: task.id,
+              family: task.family,
+              label: task.label,
+              surface,
+              iteration,
+              projectPath: fixture.projectPath,
+              ok: surfaceResult.ok && assertionFailures.length === 0,
+              durationMs: surfaceResult.durationMs,
+              invocationCount: surfaceResult.invocationCount,
+              interfaceTokenEstimate: surfaceResult.interfaceTokenEstimate,
+              stdout: surfaceResult.stdout,
+              stderr: surfaceResult.stderr,
+              assertionFailures,
+            });
+          } finally {
+            if (!args.keepFixtures) {
+              rmSync(fixture.tempRoot, { recursive: true, force: true });
+            }
+          }
+        }
+      }
+    }
+  } finally {
+    await mcp.close();
+  }
+
+  const grouped = selectedTaskIds.map((taskId) => {
+    const task = matrix.tasks.find((entry) => entry.id === taskId);
+    const taskRuns = runResults.filter((entry) => entry.taskId === taskId);
+    return {
+      taskId,
+      family: task?.family,
+      label: task?.label,
+      summary: summarize(taskRuns),
+      runs: taskRuns,
+    };
+  });
+
+  const report = {
+    benchmark: 'gopeak-cli-vs-mcp',
+    sourceProjectPath,
+    mcpProfile: matrix.baseline?.mcpProfile || 'compact',
+    iterations,
+    generatedAt: new Date().toISOString(),
+    tasks: grouped,
+  };
+
+  if (args.output) {
+    writeFileSync(resolve(args.output), JSON.stringify(report, null, 2));
+  }
+
+  console.log(JSON.stringify(report, null, 2));
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/scripts/benchmark/cli-vs-mcp.matrix.json
+++ b/scripts/benchmark/cli-vs-mcp.matrix.json
@@ -1,0 +1,116 @@
+{
+  "version": 1,
+  "baseline": {
+    "mcpProfile": "compact",
+    "notes": [
+      "Compact MCP is the primary baseline.",
+      "Validation task preserves MCP compatibility checks by activating the import_export dynamic group before validate_project."
+    ]
+  },
+  "tasks": [
+    {
+      "id": "scene_create",
+      "family": "scene_script_mutation",
+      "label": "Create scene",
+      "setup": { "kind": "fresh_copy" },
+      "cli": {
+        "command": "scene-create",
+        "args": {
+          "scenePath": "scenes/BenchmarkScene.tscn",
+          "rootNodeType": "Node2D"
+        }
+      },
+      "mcp": {
+        "calls": [
+          {
+            "tool": "scene.create",
+            "args": {
+              "scenePath": "scenes/BenchmarkScene.tscn",
+              "rootNodeType": "Node2D"
+            }
+          }
+        ]
+      },
+      "assertions": [
+        { "type": "path_exists", "path": "scenes/BenchmarkScene.tscn" }
+      ]
+    },
+    {
+      "id": "script_modify",
+      "family": "scene_script_mutation",
+      "label": "Modify script",
+      "setup": { "kind": "fresh_copy" },
+      "cli": {
+        "command": "script-modify",
+        "args": {
+          "scriptPath": "scripts/player.gd",
+          "modifications": [
+            {
+              "type": "add_function",
+              "name": "benchmark_marker",
+              "params": "",
+              "returnType": "void",
+              "body": "\tprint(\"benchmark-marker\")",
+              "position": "end"
+            }
+          ]
+        }
+      },
+      "mcp": {
+        "calls": [
+          {
+            "tool": "script.modify",
+            "args": {
+              "scriptPath": "scripts/player.gd",
+              "modifications": [
+                {
+                  "type": "add_function",
+                  "name": "benchmark_marker",
+                  "params": "",
+                  "returnType": "void",
+                  "body": "\tprint(\"benchmark-marker\")",
+                  "position": "end"
+                }
+              ]
+            }
+          }
+        ]
+      },
+      "assertions": [
+        { "type": "file_contains", "path": "scripts/player.gd", "needle": "func benchmark_marker() -> void:" }
+      ]
+    },
+    {
+      "id": "validate_project",
+      "family": "build_validation",
+      "label": "Validate project",
+      "setup": { "kind": "fresh_copy" },
+      "cli": {
+        "command": "validate-project",
+        "args": {
+          "includeSuggestions": true
+        }
+      },
+      "mcp": {
+        "calls": [
+          {
+            "tool": "tool.groups",
+            "args": {
+              "action": "activate",
+              "group": "import_export"
+            }
+          },
+          {
+            "tool": "validate_project",
+            "args": {
+              "includeSuggestions": true
+            }
+          }
+        ]
+      },
+      "assertions": [
+        { "type": "stdout_nonempty" }
+      ]
+    }
+  ]
+}

--- a/scripts/benchmark/gopeak-cli-prototype.mjs
+++ b/scripts/benchmark/gopeak-cli-prototype.mjs
@@ -1,0 +1,177 @@
+#!/usr/bin/env node
+import { execFile, exec as execCallback } from 'node:child_process';
+import { promisify } from 'node:util';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import process from 'node:process';
+
+const execAsync = promisify(execCallback);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+const operationsScriptPath = join(repoRoot, 'src', 'scripts', 'godot_operations.gd');
+
+function parseArgs(argv) {
+  const result = { _: [] };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (!token.startsWith('--')) {
+      result._.push(token);
+      continue;
+    }
+
+    const key = token.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      result[key] = true;
+      continue;
+    }
+
+    result[key] = next;
+    i += 1;
+  }
+  return result;
+}
+
+function estimateTokens(value) {
+  return Math.max(1, Math.ceil(String(value).length / 4));
+}
+
+function parseJsonArgument(value, fallback) {
+  if (!value) return fallback;
+  try {
+    return JSON.parse(value);
+  } catch (error) {
+    throw new Error(`Invalid JSON: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function runGodotOperation(operation, params, projectPath, godotPath) {
+  const payload = JSON.stringify(params ?? {});
+  const commandArgs = [
+    '--headless',
+    '--path',
+    projectPath,
+    '--script',
+    operationsScriptPath,
+    operation,
+    payload,
+  ];
+
+  return await new Promise((resolvePromise, rejectPromise) => {
+    execFile(godotPath, commandArgs, { maxBuffer: 10 * 1024 * 1024 }, (error, stdout, stderr) => {
+      if (error) {
+        resolvePromise({ ok: false, stdout, stderr, error: error.message, commandArgs });
+        return;
+      }
+      resolvePromise({ ok: true, stdout, stderr, commandArgs });
+    });
+  });
+}
+
+async function validateProject(projectPath, godotPath, preset = '', includeSuggestions = true) {
+  return await runGodotOperation(
+    'validate_project',
+    { preset, include_suggestions: includeSuggestions },
+    projectPath,
+    godotPath,
+  );
+}
+
+async function main() {
+  const parsed = parseArgs(process.argv.slice(2));
+  const [command] = parsed._;
+  const godotPath = parsed.godotPath || process.env.GODOT_PATH || 'godot';
+
+  if (!command || parsed.help) {
+    console.log([
+      'GoPeak CLI Prototype (benchmark-only)',
+      '',
+      'Commands:',
+      '  scene-create      --projectPath <dir> --scenePath <res> [--rootNodeType Node2D]',
+      '  script-modify     --projectPath <dir> --scriptPath <res> --modifications <json>',
+      '  validate-project  --projectPath <dir> [--preset <name>] [--includeSuggestions true|false]',
+      '',
+      'Output is JSON by default.',
+    ].join('\n'));
+    return;
+  }
+
+  const startedAt = Date.now();
+  let operationName = command;
+  let execution;
+
+  switch (command) {
+    case 'scene-create': {
+      if (!parsed.projectPath || !parsed.scenePath) {
+        throw new Error('scene-create requires --projectPath and --scenePath');
+      }
+      operationName = 'create_scene';
+      execution = await runGodotOperation(
+        'create_scene',
+        { scene_path: parsed.scenePath, root_node_type: parsed.rootNodeType || 'Node2D' },
+        parsed.projectPath,
+        godotPath,
+      );
+      break;
+    }
+    case 'script-modify': {
+      if (!parsed.projectPath || !parsed.scriptPath || !parsed.modifications) {
+        throw new Error('script-modify requires --projectPath, --scriptPath, and --modifications');
+      }
+      operationName = 'modify_script';
+      execution = await runGodotOperation(
+        'modify_script',
+        {
+          script_path: parsed.scriptPath,
+          modifications: parseJsonArgument(parsed.modifications, []),
+        },
+        parsed.projectPath,
+        godotPath,
+      );
+      break;
+    }
+    case 'validate-project': {
+      if (!parsed.projectPath) {
+        throw new Error('validate-project requires --projectPath');
+      }
+      operationName = 'validate_project';
+      execution = await validateProject(
+        parsed.projectPath,
+        godotPath,
+        typeof parsed.preset === 'string' ? parsed.preset : '',
+        parsed.includeSuggestions !== 'false',
+      );
+      break;
+    }
+    default:
+      throw new Error(`Unknown command: ${command}`);
+  }
+
+  const result = {
+    ok: Boolean(execution?.ok),
+    surface: 'cli-prototype',
+    command,
+    operationName,
+    invocationCount: 1,
+    interfaceTokenEstimate: estimateTokens(process.argv.slice(2).join(' ')),
+    durationMs: Date.now() - startedAt,
+    stdout: execution?.stdout?.trim() ?? '',
+    stderr: execution?.stderr?.trim() ?? '',
+    error: execution?.error ?? null,
+    commandArgs: execution?.commandArgs ?? [],
+  };
+
+  console.log(JSON.stringify(result, null, 2));
+  if (!result.ok) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(JSON.stringify({
+    ok: false,
+    surface: 'cli-prototype',
+    error: error instanceof Error ? error.message : String(error),
+  }, null, 2));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Add the standalone benchmark scripts and sample spec used to compare narrow CLI operations against the compact MCP baseline.

## Included
- benchmark matrix JSON
- standalone CLI prototype runner for benchmark use
- standalone benchmark driver
- sample benchmark spec

## Why
The project needs a reproducible script-level harness that can be iterated on independently from docs or product-positioning changes. This PR keeps the harness itself reviewable as a separate slice.

## Related issue
Closes #21

## Verification
- node --check scripts/benchmark/gopeak-cli-prototype.mjs
- node --check scripts/benchmark/cli-vs-mcp-benchmark.mjs
