### PR TITLE
fix(benchmark): classify unmet requirements as skipped

### DIFF
--- a/scripts/benchmark/cli-vs-mcp-benchmark.mjs
+++ b/scripts/benchmark/cli-vs-mcp-benchmark.mjs
@@ -224,19 +224,40 @@ async function runMcpTask(task, mcp, projectPath) {
 function summarize(results) {
   const summary = {};
   for (const surface of ['cli', 'mcp']) {
-    const surfaceRuns = results.filter((entry) => entry.surface === surface && entry.ok);
-    if (surfaceRuns.length === 0) {
-      summary[surface] = { okRuns: 0 };
-      continue;
-    }
+    const surfaceRuns = results.filter((entry) => entry.surface === surface);
+    const successfulRuns = surfaceRuns.filter((entry) => entry.ok);
+    const skippedRuns = surfaceRuns.filter((entry) => entry.skipped);
     summary[surface] = {
-      okRuns: surfaceRuns.length,
-      medianDurationMs: median(surfaceRuns.map((entry) => entry.durationMs)),
-      medianInvocationCount: median(surfaceRuns.map((entry) => entry.invocationCount)),
-      medianInterfaceTokenEstimate: median(surfaceRuns.map((entry) => entry.interfaceTokenEstimate)),
+      okRuns: successfulRuns.length,
+      skippedRuns: skippedRuns.length,
     };
+    if (successfulRuns.length > 0) {
+      summary[surface].medianDurationMs = median(successfulRuns.map((entry) => entry.durationMs));
+      summary[surface].medianInvocationCount = median(successfulRuns.map((entry) => entry.invocationCount));
+      summary[surface].medianInterfaceTokenEstimate = median(successfulRuns.map((entry) => entry.interfaceTokenEstimate));
+    }
   }
   return summary;
+}
+
+async function detectCapabilities(mcp) {
+  const capabilities = {
+    editor_bridge: false,
+  };
+
+  try {
+    const { response } = await mcp.callTool('editor.status', {});
+    const text = response?.result?.content?.map((part) => part?.text || '').join('\n') || '';
+    const parsed = text ? JSON.parse(text) : {};
+    capabilities.editor_bridge = Boolean(parsed.connected);
+  } catch {}
+
+  return capabilities;
+}
+
+function getMissingRequirements(task, surface, capabilities) {
+  const required = task.requires?.[surface] || [];
+  return required.filter((requirement) => !capabilities[requirement]);
 }
 
 async function main() {
@@ -253,6 +274,7 @@ async function main() {
     GOPEAK_TOOL_PROFILE: matrix.baseline?.mcpProfile || 'compact',
   });
   await mcp.initialize();
+  const capabilities = await detectCapabilities(mcp);
 
   const runResults = [];
   try {
@@ -266,6 +288,28 @@ async function main() {
         for (const surface of ['cli', 'mcp']) {
           const fixture = ensureProjectCopy(sourceProjectPath, `${task.id}-${surface}-${iteration}`);
           try {
+            const missingRequirements = getMissingRequirements(task, surface, capabilities);
+            if (missingRequirements.length > 0) {
+              runResults.push({
+                taskId: task.id,
+                family: task.family,
+                label: task.label,
+                surface,
+                iteration,
+                projectPath: fixture.projectPath,
+                ok: false,
+                skipped: true,
+                skipReason: `missing capabilities: ${missingRequirements.join(', ')}`,
+                durationMs: 0,
+                invocationCount: 0,
+                interfaceTokenEstimate: 0,
+                stdout: '',
+                stderr: '',
+                assertionFailures: [],
+              });
+              continue;
+            }
+
             const surfaceResult = surface === 'cli'
               ? await runCliTask(task, fixture.projectPath, godotPath)
               : await runMcpTask(task, mcp, fixture.projectPath);
@@ -278,6 +322,7 @@ async function main() {
               iteration,
               projectPath: fixture.projectPath,
               ok: surfaceResult.ok && assertionFailures.length === 0,
+              skipped: false,
               durationMs: surfaceResult.durationMs,
               invocationCount: surfaceResult.invocationCount,
               interfaceTokenEstimate: surfaceResult.interfaceTokenEstimate,
@@ -315,6 +360,7 @@ async function main() {
     mcpProfile: matrix.baseline?.mcpProfile || 'compact',
     iterations,
     generatedAt: new Date().toISOString(),
+    capabilities,
     tasks: grouped,
   };
 

--- a/scripts/benchmark/cli-vs-mcp.matrix.json
+++ b/scripts/benchmark/cli-vs-mcp.matrix.json
@@ -13,6 +13,7 @@
       "family": "scene_script_mutation",
       "label": "Create scene",
       "setup": { "kind": "fresh_copy" },
+      "requires": { "mcp": ["editor_bridge"] },
       "cli": {
         "command": "scene-create",
         "args": {

--- a/test-benchmark-cli-vs-mcp.mjs
+++ b/test-benchmark-cli-vs-mcp.mjs
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+const REPO = '/home/yun/Gopeak-godot-mcp';
+const CLI = join(REPO, 'build/cli.js');
+const SCRIPT_BENCHMARK = join(REPO, 'scripts', 'benchmark', 'cli-vs-mcp-benchmark.mjs');
+const FIXTURE = '/home/yun/gopeak-demo';
+const ARTIFACT_DIR = '/home/yun/.omx/artifacts/gopeak-cli-vs-mcp/worker-2';
+
+async function runCli(args, extraEnv = {}) {
+  const { stdout, stderr } = await execFile(process.execPath, [CLI, ...args], {
+    cwd: REPO,
+    env: { ...process.env, ...extraEnv },
+    maxBuffer: 1024 * 1024 * 10,
+  });
+  return { stdout, stderr };
+}
+
+async function main() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'gopeak-benchmark-worker-2-'));
+  const projectCopy = join(tempRoot, 'gopeak-demo');
+  const specPath = join(tempRoot, 'benchmark-spec.json');
+  const outPath = join(tempRoot, 'benchmark-report.json');
+
+  try {
+    await execFile('cp', ['-R', FIXTURE, projectCopy], { cwd: REPO, maxBuffer: 1024 * 1024 * 20 });
+
+    const help = await runCli(['help']);
+    assert.match(help.stdout, /gopeak benchmark \.\.\./);
+
+    const scriptHelp = await runCli(['script', '--help']);
+    assert.match(scriptHelp.stdout, /gopeak script create/);
+    assert.match(scriptHelp.stdout, /gopeak project export/);
+
+    const compat = await runCli(['benchmark', 'compat'], {
+      GOPEAK_TOOL_PROFILE: 'compact',
+      GOPEAK_TOOLS_PAGE_SIZE: '9999',
+    });
+    assert.match(compat.stdout, /Compatibility checks passed/);
+
+    const spec = {
+      name: 'worker-2-benchmark-smoke',
+      repetitions: 1,
+      tasks: [
+        {
+          id: 'script-create',
+          family: 'script-mutation',
+          cli: {
+            command: [
+              'script',
+              'create',
+              '--project-path', projectCopy,
+              '--script-path', 'scripts/worker2_cli_create.gd',
+              '--extends', 'Node',
+            ],
+          },
+          mcp: {
+            tool: 'script.create',
+            args: {
+              projectPath: projectCopy,
+              scriptPath: 'scripts/worker2_mcp_create.gd',
+              extends: 'Node',
+            },
+          },
+        },
+        {
+          id: 'script-modify',
+          family: 'script-mutation',
+          cli: {
+            command: [
+              'script',
+              'modify',
+              '--project-path', projectCopy,
+              '--script-path', 'scripts/worker2_cli_create.gd',
+              '--modifications', '[{"type":"add_function","name":"worker_two_cli","body":"pass"}]',
+            ],
+          },
+          mcp: {
+            tool: 'script.modify',
+            args: {
+              projectPath: projectCopy,
+              scriptPath: 'scripts/worker2_mcp_create.gd',
+              modifications: [
+                { type: 'add_function', name: 'worker_two_mcp', body: 'pass' },
+              ],
+            },
+          },
+        },
+      ],
+    };
+
+    await writeFile(specPath, JSON.stringify(spec, null, 2));
+
+    const compare = await runCli(['benchmark', 'compare', '--spec', specPath, '--out', outPath, '--runs', '1'], {
+      GOPEAK_TOOL_PROFILE: 'compact',
+      GOPEAK_TOOLS_PAGE_SIZE: '9999',
+    });
+    assert.match(compare.stdout, /Benchmark results written to/);
+
+    const report = JSON.parse(await readFile(outPath, 'utf8'));
+    assert.equal(report.runs.length, 4, `expected 4 run records, got ${report.runs.length}`);
+    assert(report.runs.every((run) => run.success === true), 'expected all benchmark runs to succeed');
+
+    await mkdir(ARTIFACT_DIR, { recursive: true });
+    await writeFile(join(ARTIFACT_DIR, 'benchmark-smoke-spec.json'), JSON.stringify(spec, null, 2));
+    await writeFile(join(ARTIFACT_DIR, 'benchmark-smoke-report.json'), JSON.stringify(report, null, 2));
+
+    const cliScript = await readFile(join(projectCopy, 'scripts/worker2_cli_create.gd'), 'utf8');
+    const mcpScript = await readFile(join(projectCopy, 'scripts/worker2_mcp_create.gd'), 'utf8');
+    assert.match(cliScript, /func worker_two_cli\(\)/);
+    assert.match(mcpScript, /func worker_two_mcp\(\)/);
+
+    const { stdout: scriptBenchmarkStdout } = await execFile(process.execPath, [
+      SCRIPT_BENCHMARK,
+      '--projectPath', projectCopy,
+      '--tasks', 'scene_create',
+      '--iterations', '1',
+    ], {
+      cwd: REPO,
+      env: { ...process.env, GOPEAK_TOOL_PROFILE: 'compact' },
+      maxBuffer: 1024 * 1024 * 20,
+    });
+    const scriptBenchmark = JSON.parse(scriptBenchmarkStdout);
+    assert.equal(scriptBenchmark.tasks[0].summary.cli.okRuns, 1);
+    assert.equal(scriptBenchmark.capabilities.editor_bridge, false);
+    assert.equal(scriptBenchmark.tasks[0].summary.mcp.okRuns, 0);
+    assert.equal(scriptBenchmark.tasks[0].summary.mcp.skippedRuns, 1);
+    assert.equal(scriptBenchmark.tasks[0].runs[1].surface, 'mcp');
+    assert.equal(scriptBenchmark.tasks[0].runs[1].skipped, true);
+    assert.equal(scriptBenchmark.tasks[0].runs[1].skipReason, 'missing capabilities: editor_bridge');
+
+    console.log('PASS test-benchmark-cli-vs-mcp');
+    console.log(`report=${outPath}`);
+    console.log(`project_copy=${projectCopy}`);
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error('FAIL test-benchmark-cli-vs-mcp');
+  console.error(error?.stack || error?.message || String(error));
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

This PR improves the **CLI-vs-MCP benchmark methodology** so benchmark families with unmet runtime requirements are classified as **skipped / non-comparable** instead of looking like hard failures.

The immediate target is `scene_create` in the current headless benchmark environment:
- the benchmark can execute the CLI path,
- the compact MCP path still depends on `editor_bridge` in this setup,
- so the benchmark should record that mismatch explicitly rather than producing a misleading failure-shaped result.

This is a benchmark-quality / interpretation fix. It is **not** a claim that CLI is now broadly faster than MCP.

---

## Why this PR exists

After the earlier benchmark/docs/prototype changes landed in `dev`, I reran the benchmark on the merged state to decide what the next improvement should be.

The reruns confirmed three things:

### 1) `scene_create` was still not fairly comparable in headless mode
In the merged-state rerun, `editor_bridge=false`.
That means:
- CLI `scene_create` can run in the selected headless benchmark setup,
- compact MCP `scene.create` cannot be exercised on the same footing,
- so treating the MCP side as a normal failed run makes the benchmark narrative worse, not better.

### 2) The comparable families still support a **hybrid** conclusion
Fresh rerun evidence from the merged state remained mixed:

- `script_modify`
  - CLI median: **578 ms**
  - MCP median: **523 ms**
  - CLI interface token estimate: **72**
  - MCP interface token estimate: **88**
  - Interpretation: CLI is more compact at the interface layer, but MCP still wins on end-to-end runtime in the current harness.

- `validate_project`
  - CLI median: **576 ms**
  - MCP median: **522 ms**
  - CLI interface token estimate: **33**
  - MCP interface token estimate: **101**
  - Interpretation: this is still the strongest **narrow CLI candidate** because it reduces interface overhead and invocation count, but it is not an end-to-end speed win.

### 3) The benchmark needed a methodology fix before any stronger product claim
The highest-value next step was not “add more CLI surface.”
It was: make the benchmark honest about **when a family is not runnable in the current environment**.

---

## What changed

### 1) Capability-aware classification in the benchmark runner
File:
- `scripts/benchmark/cli-vs-mcp-benchmark.mjs`

Changes:
- add capability detection (`detectCapabilities`) for the MCP benchmark environment
- allow tasks to declare required capabilities per surface
- when a required capability is missing, emit a run record with:
  - `ok: false`
  - `skipped: true`
  - `skipReason: ...`
- summarize skipped runs separately from successful runs
- include environment capabilities in the generated benchmark report

Practical effect:
- a workflow can now be classified as **non-comparable in the current environment** without being misread as a normal product failure.

### 2) Matrix-level requirement for the MCP `scene_create` lane
File:
- `scripts/benchmark/cli-vs-mcp.matrix.json`

Change:
- `scene_create` now declares an MCP-side requirement for `editor_bridge`

Practical effect:
- in headless runs where `editor_bridge` is unavailable, the benchmark records the MCP lane as skipped/non-comparable instead of pretending it was a fair head-to-head runtime result.

### 3) Regression coverage for the new benchmark behavior
File:
- `test-benchmark-cli-vs-mcp.mjs`

Change:
- extend the test to run the standalone benchmark for `scene_create`
- assert that, when `editor_bridge` is unavailable:
  - CLI still records `okRuns = 1`
  - MCP records `okRuns = 0`
  - MCP records `skippedRuns = 1`
  - the skip reason is `missing capabilities: editor_bridge`

Practical effect:
- the intended benchmark interpretation is now test-covered, rather than being left to convention.

---

## What this PR does **not** do

This PR does **not**:
- claim a blanket CLI performance victory
- change the current hybrid benchmark conclusion
- make `scene_create` comparable in the current headless setup
- add new CLI prototype functionality
- change public product positioning by itself

The goal is narrower and more practical:
> make the benchmark output more truthful when environment constraints make a family non-comparable.

---

## Benchmark interpretation after this PR

With this change in place, the benchmark should now be read like this:

### Comparable families
- `script_modify`
  - comparable
  - MCP still runtime-favored
- `validate_project`
  - comparable
  - CLI remains a narrow interface-efficiency candidate

### Non-comparable family in current headless setup
- `scene_create`
  - skipped / non-comparable when `editor_bridge` is unavailable
  - should not be cited as a CLI or MCP win/loss in this environment

That keeps the overall conclusion where it already was:
- **current recommendation remains cautious and hybrid**

---

## Verification

Ran on the clean replacement branch built from current `origin/dev` + this benchmark-methodology fix:

- `npm run typecheck` ✅
- `npm run build` ✅
- `node test-benchmark-cli-vs-mcp.mjs` ✅

The regression test now verifies the exact capability-aware skip behavior for `scene_create` in the current environment.

---

## Reviewer guidance

Please review this PR as a **benchmark-methodology improvement**.

Key questions:
1. Does the runner now distinguish comparable vs non-comparable families clearly enough?
2. Is the `editor_bridge` requirement for MCP `scene_create` encoded in the right place?
3. Does the regression test cover the intended skip/non-comparable behavior precisely enough?
4. Does the PR avoid overclaiming product conclusions that the benchmark still does not support?

---

## Branch / PR note

This PR supersedes the earlier overly broad benchmark-methodology PR draft by rebuilding the change on top of current `dev` with only the intended benchmark-classification diff.
