### PR TITLE
fix: sanitize exposed tool names for OpenAI-compatible clients

### DIFF
--- a/scripts/smoke-test.mjs
+++ b/scripts/smoke-test.mjs
@@ -5,6 +5,8 @@ import { setTimeout as delay } from 'node:timers/promises';
 import process from 'node:process';
 import { WebSocket } from 'ws';
 
+const OPENAI_COMPATIBLE_TOOL_NAME_PATTERN = /^[a-zA-Z0-9-]{1,128}$/;
+
 function parseResponses(data) {
   return data
     .split('\n')
@@ -149,6 +151,12 @@ async function main() {
     const tools = parseResponses(stdout).find((message) => message?.id === TOOLS_LIST_ID && Array.isArray(message?.result?.tools));
     if (!tools || tools.result.tools.length === 0) {
       throw new Error('missing tools/list response');
+    }
+    const invalidToolNames = tools.result.tools
+      .map((tool) => tool?.name)
+      .filter((name) => typeof name !== 'string' || !OPENAI_COMPATIBLE_TOOL_NAME_PATTERN.test(name));
+    if (invalidToolNames.length > 0) {
+      throw new Error(`tools/list exposed invalid OpenAI-compatible tool names: ${invalidToolNames.join(', ')}`);
     }
 
     await connectWebSocket(`ws://${host}:${port}/visualizer`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -909,8 +909,48 @@ class GodotServer {
     return handleDAPTool(this.dapClient, toolName, args);
   }
 
+  private sanitizeExportedToolName(toolName: string): string {
+    const sanitized = toolName
+      .normalize('NFKD')
+      .replace(/[^\x00-\x7F]/g, '')
+      .replace(/[^a-zA-Z0-9-]+/g, '-')
+      .replace(/-+/g, '-')
+      .replace(/^-+|-+$/g, '')
+      .slice(0, 128);
+
+    return sanitized.length > 0 ? sanitized : 'tool';
+  }
+
+  private buildToolNameResolutionMap(allTools: MCPToolDefinition[]): Map<string, string> {
+    const resolutionMap = new Map<string, string>();
+
+    const register = (candidateName: string, resolvedName: string) => {
+      const existing = resolutionMap.get(candidateName);
+      if (existing && existing !== resolvedName) {
+        throw new Error(`Sanitized tool name collision: "${candidateName}" maps to both "${existing}" and "${resolvedName}"`);
+      }
+      resolutionMap.set(candidateName, resolvedName);
+    };
+
+    for (const tool of allTools) {
+      register(tool.name, tool.name);
+      register(this.sanitizeExportedToolName(tool.name), tool.name);
+    }
+
+    for (const [compactName, legacyName] of Object.entries(this.compactAliasToLegacy)) {
+      register(compactName, legacyName);
+      register(this.sanitizeExportedToolName(compactName), legacyName);
+    }
+
+    return resolutionMap;
+  }
+
   private resolveToolAlias(requestedToolName: string): string {
-    return this.compactAliasToLegacy[requestedToolName] || requestedToolName;
+    const allTools = this.getAllToolDefinitions();
+    const resolutionMap = this.buildToolNameResolutionMap(allTools);
+    return resolutionMap.get(requestedToolName)
+      || resolutionMap.get(this.sanitizeExportedToolName(requestedToolName))
+      || requestedToolName;
   }
 
   private buildCompactTools(allTools: MCPToolDefinition[]): MCPToolDefinition[] {
@@ -930,6 +970,31 @@ class GodotServer {
     }
 
     return compactTools;
+  }
+
+  private sanitizeToolsForList(tools: MCPToolDefinition[]): MCPToolDefinition[] {
+    const seenNames = new Map<string, string>();
+
+    return tools.map((tool) => {
+      const sanitizedName = this.sanitizeExportedToolName(tool.name);
+      const existing = seenNames.get(sanitizedName);
+      if (existing && existing !== tool.name) {
+        throw new Error(`Sanitized tool name collision in tools/list: "${sanitizedName}" from "${existing}" and "${tool.name}"`);
+      }
+
+      seenNames.set(sanitizedName, tool.name);
+
+      if (sanitizedName !== tool.name) {
+        this.logDebug(`Exporting tool "${tool.name}" as "${sanitizedName}" for OpenAI-compatible clients`);
+      }
+
+      return sanitizedName === tool.name
+        ? tool
+        : {
+            ...tool,
+            name: sanitizedName,
+          };
+    });
   }
 
   private getExposedTools(allTools: MCPToolDefinition[]): MCPToolDefinition[] {
@@ -3809,7 +3874,7 @@ class GodotServer {
       const allTools = buildToolDefinitions();
       this.cachedToolDefinitions = allTools;
 
-      const exposedTools = this.getExposedTools(allTools);
+      const exposedTools = this.sanitizeToolsForList(this.getExposedTools(allTools));
       return this.paginateToolsForList(exposedTools, request.params?.cursor);
     });
 

--- a/test-bridge.mjs
+++ b/test-bridge.mjs
@@ -19,6 +19,7 @@ const BRIDGE_HOST = process.env.GOPEAK_BRIDGE_HOST || process.env.GODOT_BRIDGE_H
 const GODOT_PATH = process.env.GODOT_PATH || '/home/doyun/Apps/godot-4.6-rc2/Godot_v4.6-rc2_linux.x86_64';
 const TEST_PROJECT = process.env.GOPEAK_TEST_PROJECT || '/home/doyun/gopeak-smoke-test';
 const RUNTIME_PORT = 7777;
+const OPENAI_COMPATIBLE_TOOL_NAME_PATTERN = /^[a-zA-Z0-9-]{1,128}$/;
 
 let passed = 0;
 let failed = 0;
@@ -57,6 +58,20 @@ function parseTextContent(response) {
   } catch {
     return null;
   }
+}
+
+function sanitizeToolName(name) {
+  return name
+    .normalize('NFKD')
+    .replace(/[^\x00-\x7F]/g, '')
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 128) || 'tool';
+}
+
+function expandToolCandidates(...names) {
+  return [...new Set(names.filter(Boolean).flatMap((name) => [name, sanitizeToolName(name)]))];
 }
 
 function chooseTool(toolNames, preferred) {
@@ -215,7 +230,7 @@ async function main() {
   console.log('\n📚 Testing tool catalog before tools/list...');
   let catalogToolName = 'tool.catalog';
   let catalogPayload = null;
-  for (const candidate of ['tool.catalog', 'tool_catalog']) {
+  for (const candidate of expandToolCandidates('tool.catalog', 'tool_catalog')) {
     stdout = '';
     server.stdin.write(rpcMsg('tools/call', { name: candidate, arguments: { limit: 20 } }));
     await delay(1000);
@@ -242,8 +257,8 @@ async function main() {
     const knownToolResponses = parseResponses(stdout);
     const knownToolPayload = parseTextContent(knownToolResponses.find(response => response.result?.content));
     const catalogIncludesKnownTool = Array.isArray(knownToolPayload?.tools) && knownToolPayload.tools.some((entry) => {
-      return ['create_scene', 'scene.create'].includes(entry?.tool)
-        || ['create_scene', 'scene.create'].includes(entry?.compactAlias);
+      return expandToolCandidates('create_scene', 'scene.create').includes(entry?.tool)
+        || expandToolCandidates('create_scene', 'scene.create').includes(entry?.compactAlias);
     });
     if (catalogIncludesKnownTool) {
       ok(`${catalogToolName} query includes known tool entry`);
@@ -292,25 +307,33 @@ async function main() {
   try {
     const tools = await listAllTools();
     const toolNames = new Set(tools.map(tool => tool.name));
-    const isCompactProfile = Array.from(toolNames).some(name => name.includes('.'));
+    const invalidToolNames = tools
+      .map((tool) => tool?.name)
+      .filter((name) => typeof name !== 'string' || !OPENAI_COMPATIBLE_TOOL_NAME_PATTERN.test(name));
+    const isCompactProfile = (process.env.GOPEAK_TOOL_PROFILE || 'compact') === 'compact';
     const hasTool = (...names) => names.filter(Boolean).some(name => toolNames.has(name));
 
     ok(`tools/list returned ${tools.length} tools across all pages`);
+    if (invalidToolNames.length === 0) {
+      ok('tools/list names are OpenAI-compatible');
+    } else {
+      fail('tools/list name validation', invalidToolNames.join(', '));
+    }
 
-    if (hasTool('get_editor_status', 'editor.status')) {
+    if (hasTool(...expandToolCandidates('get_editor_status', 'editor.status'))) {
       ok('get_editor_status/editor.status tool registered');
     } else {
       fail('get_editor_status/editor.status', 'Not found in tool list');
     }
-    statusToolName = chooseTool(toolNames, ['editor.status', 'get_editor_status']);
-    runtimeStatusToolName = chooseTool(toolNames, ['runtime.status', 'get_runtime_status']);
-    inspectRuntimeTreeToolName = chooseTool(toolNames, ['inspect_runtime_tree']);
-    setRuntimePropertyToolName = chooseTool(toolNames, ['set_runtime_property']);
-    callRuntimeMethodToolName = chooseTool(toolNames, ['call_runtime_method']);
-    getRuntimeMetricsToolName = chooseTool(toolNames, ['get_runtime_metrics']);
-    sceneCreateToolName = chooseTool(toolNames, ['scene.create', 'create_scene']);
-    captureScreenshotToolName = chooseTool(toolNames, ['capture_screenshot']);
-    captureViewportToolName = chooseTool(toolNames, ['capture_viewport']);
+    statusToolName = chooseTool(toolNames, expandToolCandidates('editor.status', 'get_editor_status'));
+    runtimeStatusToolName = chooseTool(toolNames, expandToolCandidates('runtime.status', 'get_runtime_status'));
+    inspectRuntimeTreeToolName = chooseTool(toolNames, expandToolCandidates('inspect_runtime_tree'));
+    setRuntimePropertyToolName = chooseTool(toolNames, expandToolCandidates('set_runtime_property'));
+    callRuntimeMethodToolName = chooseTool(toolNames, expandToolCandidates('call_runtime_method'));
+    getRuntimeMetricsToolName = chooseTool(toolNames, expandToolCandidates('get_runtime_metrics'));
+    sceneCreateToolName = chooseTool(toolNames, expandToolCandidates('scene.create', 'create_scene'));
+    captureScreenshotToolName = chooseTool(toolNames, expandToolCandidates('capture_screenshot'));
+    captureViewportToolName = chooseTool(toolNames, expandToolCandidates('capture_viewport'));
 
     const migratedTools = [
       { legacy: 'create_scene', compact: 'scene.create' },
@@ -321,7 +344,7 @@ async function main() {
     ];
 
     for (const { legacy, compact } of migratedTools) {
-      if (hasTool(legacy, compact)) {
+      if (hasTool(...expandToolCandidates(legacy, compact))) {
         ok(`Tool '${compact || legacy}' registered`);
       } else if (isCompactProfile && !compact) {
         ok(`Tool '${legacy}' omitted by compact profile (expected)`);
@@ -803,11 +826,10 @@ async function main() {
     }
 
     // Regression: issue #7 (missing args must fail fast and must not emit tool_invoke)
-    const missingArgsToolName = chooseTool(new Set([sceneCreateToolName, 'scene.create', 'create_scene']), [
-      sceneCreateToolName,
-      'scene.create',
-      'create_scene',
-    ]);
+    const missingArgsToolName = chooseTool(
+      new Set(expandToolCandidates(sceneCreateToolName, 'scene.create', 'create_scene')),
+      expandToolCandidates(sceneCreateToolName, 'scene.create', 'create_scene'),
+    );
     const unexpectedInvokes = [];
     const missingArgsCapture = (data) => {
       try {

--- a/test-dynamic-groups.mjs
+++ b/test-dynamic-groups.mjs
@@ -11,6 +11,18 @@ let passCount = 0;
 let failCount = 0;
 let nextId = 1;
 
+const OPENAI_COMPATIBLE_TOOL_NAME_PATTERN = /^[a-zA-Z0-9-]{1,128}$/;
+
+function sanitizeToolName(name) {
+  return name
+    .normalize('NFKD')
+    .replace(/[^\x00-\x7F]/g, '')
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 128) || 'tool';
+}
+
 function pass(message) {
   passCount += 1;
   console.log(`PASS: ${message}`);
@@ -207,6 +219,9 @@ async function main() {
 
     const initialTools = await listAllTools(client);
     const initialToolNames = new Set(initialTools.map((tool) => tool.name));
+    const invalidInitialToolNames = initialTools
+      .map((tool) => tool.name)
+      .filter((name) => !OPENAI_COMPATIBLE_TOOL_NAME_PATTERN.test(name));
 
     assert(
       initialTools.length === 33,
@@ -214,12 +229,17 @@ async function main() {
       `Expected 33 initial tools, got ${initialTools.length}`,
     );
     assert(
-      initialToolNames.has('tool.groups'),
-      'Compact alias tool.groups is available',
-      'Compact alias tool.groups is missing',
+      invalidInitialToolNames.length === 0,
+      'Initial tools/list names are OpenAI-compatible',
+      `Invalid tool names in initial tools/list response: ${invalidInitialToolNames.join(', ')}`,
     );
     assert(
-      !initialToolNames.has('create_animation'),
+      initialToolNames.has(sanitizeToolName('tool.groups')),
+      'Sanitized compact alias for tool.groups is available',
+      'Sanitized compact alias for tool.groups is missing',
+    );
+    assert(
+      !initialToolNames.has(sanitizeToolName('create_animation')),
       'Animation legacy tool is hidden by default',
       'Animation legacy tool should not be exposed before activation',
     );
@@ -252,9 +272,9 @@ async function main() {
     ];
 
     assert(
-      animationGroupTools.every((name) => postActivationNames.has(name)),
+      animationGroupTools.every((name) => postActivationNames.has(sanitizeToolName(name))),
       'After activation, exposed tools include animation group tools',
-      `Missing animation tools after activation: ${animationGroupTools.filter((name) => !postActivationNames.has(name)).join(', ')}`,
+      `Missing animation tools after activation: ${animationGroupTools.filter((name) => !postActivationNames.has(sanitizeToolName(name))).join(', ')}`,
     );
 
     const statusResponse = await client.send('tools/call', {
@@ -291,9 +311,9 @@ async function main() {
       `Expected 33 tools after reset, got ${afterResetTools.length}`,
     );
     assert(
-      animationGroupTools.every((name) => !afterResetNames.has(name)),
+      animationGroupTools.every((name) => !afterResetNames.has(sanitizeToolName(name))),
       'After reset, animation group tools are no longer exposed',
-      `Animation tools still exposed after reset: ${animationGroupTools.filter((name) => afterResetNames.has(name)).join(', ')}`,
+      `Animation tools still exposed after reset: ${animationGroupTools.filter((name) => afterResetNames.has(sanitizeToolName(name))).join(', ')}`,
     );
 
     console.log(`\nSummary: ${passCount} passed, ${failCount} failed`);

--- a/test-e2e-dynamic-groups.mjs
+++ b/test-e2e-dynamic-groups.mjs
@@ -24,6 +24,16 @@ let passed = 0;
 let failed = 0;
 let serverProcess = null;
 
+function sanitizeToolName(name) {
+  return name
+    .normalize('NFKD')
+    .replace(/[^\x00-\x7F]/g, '')
+    .replace(/[^a-zA-Z0-9-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 128) || 'tool';
+}
+
 function assert(condition, label) {
   if (condition) {
     console.log(`  PASS: ${label}`);
@@ -163,11 +173,11 @@ async function run() {
   assert(initialTools.length === 33, `Initial tool count = ${initialTools.length} (expected 33)`);
 
   const toolNames1 = initialTools.map(t => t.name);
-  assert(toolNames1.includes('tool.catalog'), 'tool.catalog is exposed');
-  assert(toolNames1.includes('tool.groups'), 'tool.groups is exposed');
-  assert(!toolNames1.includes('create_animation'), 'create_animation is hidden');
-  assert(!toolNames1.includes('create_audio_bus'), 'create_audio_bus is hidden');
-  assert(!toolNames1.includes('dap_set_breakpoint'), 'dap_set_breakpoint is hidden');
+  assert(toolNames1.includes(sanitizeToolName('tool.catalog')), 'sanitized tool.catalog is exposed');
+  assert(toolNames1.includes(sanitizeToolName('tool.groups')), 'sanitized tool.groups is exposed');
+  assert(!toolNames1.includes(sanitizeToolName('create_animation')), 'create_animation is hidden');
+  assert(!toolNames1.includes(sanitizeToolName('create_audio_bus')), 'create_audio_bus is hidden');
+  assert(!toolNames1.includes(sanitizeToolName('dap_set_breakpoint')), 'dap_set_breakpoint is hidden');
 
   // ── Phase 3: tool_catalog auto-activation ─────────────────
   console.log('\n[Phase 3] tool_catalog auto-activation');
@@ -188,11 +198,11 @@ async function run() {
   const { response: listRes2 } = await sendAndReceiveById(proc,
     makeRequest('tools/list', {}, 4), 4);
   const toolNames2 = listRes2.result.tools.map(t => t.name);
-  assert(toolNames2.includes('create_animation'), 'create_animation now exposed after activation');
-  assert(toolNames2.includes('add_animation_track'), 'add_animation_track now exposed');
-  assert(toolNames2.includes('create_animation_tree'), 'create_animation_tree now exposed');
-  assert(toolNames2.includes('add_animation_state'), 'add_animation_state now exposed');
-  assert(toolNames2.includes('connect_animation_states'), 'connect_animation_states now exposed');
+  assert(toolNames2.includes(sanitizeToolName('create_animation')), 'create_animation now exposed after activation');
+  assert(toolNames2.includes(sanitizeToolName('add_animation_track')), 'add_animation_track now exposed');
+  assert(toolNames2.includes(sanitizeToolName('create_animation_tree')), 'create_animation_tree now exposed');
+  assert(toolNames2.includes(sanitizeToolName('add_animation_state')), 'add_animation_state now exposed');
+  assert(toolNames2.includes(sanitizeToolName('connect_animation_states')), 'connect_animation_states now exposed');
   assert(toolNames2.length === 33 + 5, `Tool count after animation activation = ${toolNames2.length} (expected 38)`);
 
   // ── Phase 4: Multi-group activation (catalog + manual) ────
@@ -225,9 +235,9 @@ async function run() {
   const { response: listRes3 } = await sendAndReceiveById(proc,
     makeRequest('tools/list', {}, 7), 7);
   const toolNames3 = listRes3.result.tools.map(t => t.name);
-  assert(toolNames3.includes('create_audio_bus'), 'create_audio_bus exposed (audio group)');
-  assert(toolNames3.includes('dap_set_breakpoint'), 'dap_set_breakpoint exposed (dap group)');
-  assert(toolNames3.includes('dap_get_stack_trace'), 'dap_get_stack_trace exposed (dap group)');
+  assert(toolNames3.includes(sanitizeToolName('create_audio_bus')), 'create_audio_bus exposed (audio group)');
+  assert(toolNames3.includes(sanitizeToolName('dap_set_breakpoint')), 'dap_set_breakpoint exposed (dap group)');
+  assert(toolNames3.includes(sanitizeToolName('dap_get_stack_trace')), 'dap_get_stack_trace exposed (dap group)');
   assert(toolNames3.length === 33 + 5 + 4 + 6, `Tool count with 3 groups = ${toolNames3.length} (expected 48)`);
 
   // ── Phase 5: manage_tool_groups status & list ──────────────
@@ -277,9 +287,9 @@ async function run() {
   const { response: listRes4 } = await sendAndReceiveById(proc,
     makeRequest('tools/list', {}, 11), 11);
   const toolNames4 = listRes4.result.tools.map(t => t.name);
-  assert(!toolNames4.includes('create_audio_bus'), 'create_audio_bus hidden after deactivation');
-  assert(toolNames4.includes('create_animation'), 'create_animation still exposed');
-  assert(toolNames4.includes('dap_set_breakpoint'), 'dap_set_breakpoint still exposed');
+  assert(!toolNames4.includes(sanitizeToolName('create_audio_bus')), 'create_audio_bus hidden after deactivation');
+  assert(toolNames4.includes(sanitizeToolName('create_animation')), 'create_animation still exposed');
+  assert(toolNames4.includes(sanitizeToolName('dap_set_breakpoint')), 'dap_set_breakpoint still exposed');
   assert(toolNames4.length === 33 + 5 + 6, `Tool count after audio deactivation = ${toolNames4.length} (expected 44)`);
 
   // ── Phase 7: Reset ──────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR resolves issue #29 by sanitizing every exported tool name that is exposed through the OpenAI-compatible `tools/list` surface, while preserving backward-compatible dispatch to the original internal tool implementations.

In practical terms, it ensures that OpenAI-compatible adapters no longer reject the entire request because one tool name contains characters outside the allowed pattern:

`^[a-zA-Z0-9-]{1,128}$`

## Why this change is needed
Issue #29 described a boundary-layer failure, not a model failure.

The underlying tools could be valid and useful, but the OpenAI-compatible adapter would reject the whole request before execution if even one exported tool name contained unsupported characters such as:

- `_`
- `.`
- `:`
- spaces
- non-ASCII characters

That kind of failure is disproportionately expensive because:

1. the request fails before the user gets any tool execution,
2. the error often points to an array index like `tools.13`, which is hard to map back to a human-readable tool, and
3. the failure lives at the protocol export boundary, so the user cannot work around it easily from the client side.

## Direction and prior history considered
I checked this change against the repository's recent tool-surface direction before keeping PR #33 as the issue-29 delivery path.

Recent history already shows a strong pattern of hardening the external tool contract rather than leaving sharp edges to client adapters:

- dynamic/compact tool exposure work
- bridge argument normalization and validation hardening
- catalog/discovery improvements for exposed tools

This PR follows that exact direction: it makes the exported tool surface safer and more adapter-compatible without changing the internal tool architecture more than necessary.

## What changed
### 1. Sanitized exported tool names on the `tools/list` path
Names are normalized so exported tool definitions comply with OpenAI-compatible tool-name requirements.

### 2. Preserved dispatch compatibility
Sanitized exported names are mapped back to the correct original/internal tool definitions so that callers can still reach the intended tool behavior even when the export name differs from the legacy internal name.

### 3. Added collision detection
The PR explicitly guards against different internal tools collapsing to the same sanitized exported name.

That matters because silent collisions would replace one protocol bug with another, more subtle routing bug.

### 4. Added regression coverage
Tests were updated so the compatibility guarantee is enforced across:

- smoke coverage
- bridge/integration coverage
- dynamic tool-group coverage

## Why I chose this approach
I chose to sanitize at the export boundary rather than rename the entire internal tool surface because the issue is specifically about OpenAI-compatible exposure.

That gives the smallest safe fix:

- external clients receive valid names,
- internal routing remains intact,
- legacy/internal naming does not need a large refactor,
- compatibility is enforced exactly where the protocol mismatch occurred.

## Verification
I re-verified the PR branch on 2026-03-21 with:

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm run test:smoke`
- `node test-dynamic-groups.mjs`
- `GOPEAK_TEST_PROJECT=/home/yun/gopeak-demo node test-bridge.mjs`

Results:

- dynamic group test: passed
- bridge integration test: **38 passed, 0 failed**
- smoke verification: passed

These checks confirm that:

- exported tool names are OpenAI-compatible,
- sanitized aliases still resolve correctly,
- the compatibility fix does not break existing bridge-backed behavior.

## Risk / tradeoff notes
The main risk area was name-collision behavior after sanitization. This PR addresses that directly with collision detection instead of assuming sanitization is always one-to-one.

The other important constraint was backward compatibility: exported names may change shape, but the actual tool routing must not become brittle. That is why the resolution map is a core part of the fix rather than an optional add-on.

## Files changed
- `src/index.ts`
- `scripts/smoke-test.mjs`
- `test-bridge.mjs`
- `test-dynamic-groups.mjs`
- `test-e2e-dynamic-groups.mjs`

Closes #29.
