### PR TITLE
fix(runtime): relay live runtime-addon data for inspection tools

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7697,32 +7697,15 @@ class GodotServer {
     }
 
     try {
-      // Runtime inspection requires a running Godot instance
-      if (!this.activeProcess) {
-        return this.createErrorResponse(
-          'No active Godot process',
-          ['Use run_project to start a Godot instance first']
-        );
-      }
-
-      // Return information about the running process
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            status: 'running',
-            nodePath: args.nodePath || '/',
-            depth: args.depth || 3,
-            note: 'Runtime tree inspection requires the godot_mcp_runtime addon. Current output shows debug logs.',
-            recentOutput: this.activeProcess.output.slice(-20),
-            recentErrors: this.activeProcess.errors.slice(-10),
-          }, null, 2),
-        }],
-      };
+      return await this.handleRuntimeCommand('get_tree', {
+        root: args.nodePath || '/root',
+        depth: args.depth || 3,
+        include_properties: Boolean(args.includeProperties),
+      });
     } catch (error: any) {
       return this.createErrorResponse(
         `Failed to inspect runtime tree: ${error?.message || 'Unknown error'}`,
-        ['Ensure a Godot process is running']
+        ['Ensure a Godot process is running with the runtime addon enabled']
       );
     }
   }
@@ -7741,28 +7724,11 @@ class GodotServer {
     }
 
     try {
-      if (!this.activeProcess) {
-        return this.createErrorResponse(
-          'No active Godot process',
-          ['Use run_project to start a Godot instance first']
-        );
-      }
-
-      // Runtime property modification requires the addon
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            status: 'not_implemented',
-            note: 'Runtime property modification requires the godot_mcp_runtime addon installed in the running project.',
-            requested: {
-              nodePath: args.nodePath,
-              property: args.property,
-              value: args.value,
-            },
-          }, null, 2),
-        }],
-      };
+      return await this.handleRuntimeCommand('set_property', {
+        path: args.nodePath,
+        property: args.property,
+        value: args.value,
+      });
     } catch (error: any) {
       return this.createErrorResponse(
         `Failed to set runtime property: ${error?.message || 'Unknown error'}`,
@@ -7785,28 +7751,11 @@ class GodotServer {
     }
 
     try {
-      if (!this.activeProcess) {
-        return this.createErrorResponse(
-          'No active Godot process',
-          ['Use run_project to start a Godot instance first']
-        );
-      }
-
-      // Runtime method calling requires the addon
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            status: 'not_implemented',
-            note: 'Runtime method calling requires the godot_mcp_runtime addon installed in the running project.',
-            requested: {
-              nodePath: args.nodePath,
-              method: args.method,
-              args: args.args || [],
-            },
-          }, null, 2),
-        }],
-      };
+      return await this.handleRuntimeCommand('call_method', {
+        path: args.nodePath,
+        method: args.method,
+        args: Array.isArray(args.args) ? args.args : [],
+      });
     } catch (error: any) {
       return this.createErrorResponse(
         `Failed to call runtime method: ${error?.message || 'Unknown error'}`,
@@ -7829,28 +7778,9 @@ class GodotServer {
     }
 
     try {
-      if (!this.activeProcess) {
-        return this.createErrorResponse(
-          'No active Godot process',
-          ['Use run_project to start a Godot instance first']
-        );
-      }
-
-      // Basic metrics from process output
-      return {
-        content: [{
-          type: 'text',
-          text: JSON.stringify({
-            status: 'running',
-            metrics: {
-              outputLines: this.activeProcess.output.length,
-              errorLines: this.activeProcess.errors.length,
-              note: 'Detailed metrics require the godot_mcp_runtime addon.',
-            },
-            requestedMetrics: args.metrics || 'all',
-          }, null, 2),
-        }],
-      };
+      return await this.handleRuntimeCommand('get_metrics', {
+        metrics: Array.isArray(args.metrics) ? args.metrics : [],
+      });
     } catch (error: any) {
       return this.createErrorResponse(
         `Failed to get runtime metrics: ${error?.message || 'Unknown error'}`,

--- a/test-bridge.mjs
+++ b/test-bridge.mjs
@@ -282,6 +282,10 @@ async function main() {
 
   let statusToolName = 'get_editor_status';
   let runtimeStatusToolName = 'get_runtime_status';
+  let inspectRuntimeTreeToolName = 'inspect_runtime_tree';
+  let setRuntimePropertyToolName = 'set_runtime_property';
+  let callRuntimeMethodToolName = 'call_runtime_method';
+  let getRuntimeMetricsToolName = 'get_runtime_metrics';
   let sceneCreateToolName = 'create_scene';
   let captureScreenshotToolName = 'capture_screenshot';
   let captureViewportToolName = 'capture_viewport';
@@ -300,6 +304,10 @@ async function main() {
     }
     statusToolName = chooseTool(toolNames, ['editor.status', 'get_editor_status']);
     runtimeStatusToolName = chooseTool(toolNames, ['runtime.status', 'get_runtime_status']);
+    inspectRuntimeTreeToolName = chooseTool(toolNames, ['inspect_runtime_tree']);
+    setRuntimePropertyToolName = chooseTool(toolNames, ['set_runtime_property']);
+    callRuntimeMethodToolName = chooseTool(toolNames, ['call_runtime_method']);
+    getRuntimeMetricsToolName = chooseTool(toolNames, ['get_runtime_metrics']);
     sceneCreateToolName = chooseTool(toolNames, ['scene.create', 'create_scene']);
     captureScreenshotToolName = chooseTool(toolNames, ['capture_screenshot']);
     captureViewportToolName = chooseTool(toolNames, ['capture_viewport']);
@@ -425,6 +433,51 @@ async function main() {
         socket.write(`${JSON.stringify({ type: 'welcome', protocol: 'godot_mcp_runtime', version: '1.0.0' })}\n`);
         if (request.command === 'ping') {
           socket.write(`${JSON.stringify({ type: 'pong', id: request.id, timestamp: Date.now() })}\n`);
+        } else if (request.command === 'get_tree') {
+          socket.write(`${JSON.stringify({
+            type: 'tree',
+            id: request.id,
+            root: {
+              name: 'root',
+              type: 'Node',
+              path: request.params?.root || '/root',
+              children: [
+                {
+                  name: 'Player',
+                  type: 'CharacterBody2D',
+                  path: `${request.params?.root || '/root'}/Player`,
+                },
+              ],
+            },
+          })}\n`);
+        } else if (request.command === 'set_property') {
+          socket.write(`${JSON.stringify({
+            type: 'property_set',
+            id: request.id,
+            path: request.params?.path,
+            property: request.params?.property,
+            old_value: false,
+            new_value: request.params?.value,
+          })}\n`);
+        } else if (request.command === 'call_method') {
+          socket.write(`${JSON.stringify({
+            type: 'method_result',
+            id: request.id,
+            path: request.params?.path,
+            method: request.params?.method,
+            result: {
+              echoed_args: request.params?.args || [],
+            },
+          })}\n`);
+        } else if (request.command === 'get_metrics') {
+          socket.write(`${JSON.stringify({
+            type: 'metrics',
+            id: request.id,
+            data: {
+              fps: 60,
+              object_node_count: 42,
+            },
+          })}\n`);
         } else if (request.command === 'capture_screenshot' || request.command === 'capture_viewport') {
           socket.write(`${JSON.stringify({
             type: 'screenshot',
@@ -460,6 +513,66 @@ async function main() {
     ok('get_runtime_status reports connected when runtime addon responds to ping');
   } else {
     fail('get_runtime_status connected state', JSON.stringify(runtimeConnectedResponses[0] || null));
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: inspectRuntimeTreeToolName,
+    arguments: { projectPath: TEST_PROJECT, nodePath: '/root', depth: 2 }
+  }));
+  await delay(1500);
+
+  const inspectRuntimeResponses = parseResponses(stdout);
+  const inspectRuntimePayload = parseTextContent(inspectRuntimeResponses.find(response => response.result?.content));
+  if (inspectRuntimePayload?.type === 'tree' && inspectRuntimePayload?.root?.path === '/root') {
+    ok('inspect_runtime_tree relays runtime tree data from addon');
+  } else {
+    fail('inspect_runtime_tree relay', JSON.stringify(inspectRuntimeResponses[0] || null));
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: setRuntimePropertyToolName,
+    arguments: { projectPath: TEST_PROJECT, nodePath: '/root/Player', property: 'visible', value: true }
+  }));
+  await delay(1500);
+
+  const setRuntimePropertyResponses = parseResponses(stdout);
+  const setRuntimePropertyPayload = parseTextContent(setRuntimePropertyResponses.find(response => response.result?.content));
+  if (setRuntimePropertyPayload?.type === 'property_set' && setRuntimePropertyPayload?.new_value === true) {
+    ok('set_runtime_property relays addon property updates');
+  } else {
+    fail('set_runtime_property relay', JSON.stringify(setRuntimePropertyResponses[0] || null));
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: callRuntimeMethodToolName,
+    arguments: { projectPath: TEST_PROJECT, nodePath: '/root/Player', method: 'jump', args: [1, 2] }
+  }));
+  await delay(1500);
+
+  const callRuntimeMethodResponses = parseResponses(stdout);
+  const callRuntimeMethodPayload = parseTextContent(callRuntimeMethodResponses.find(response => response.result?.content));
+  if (callRuntimeMethodPayload?.type === 'method_result' && Array.isArray(callRuntimeMethodPayload?.result?.echoed_args)) {
+    ok('call_runtime_method relays addon method results');
+  } else {
+    fail('call_runtime_method relay', JSON.stringify(callRuntimeMethodResponses[0] || null));
+  }
+
+  stdout = '';
+  server.stdin.write(rpcMsg('tools/call', {
+    name: getRuntimeMetricsToolName,
+    arguments: { projectPath: TEST_PROJECT, metrics: ['fps'] }
+  }));
+  await delay(1500);
+
+  const runtimeMetricsResponses = parseResponses(stdout);
+  const runtimeMetricsPayload = parseTextContent(runtimeMetricsResponses.find(response => response.result?.content));
+  if (runtimeMetricsPayload?.type === 'metrics' && runtimeMetricsPayload?.data?.fps === 60) {
+    ok('get_runtime_metrics relays addon metrics');
+  } else {
+    fail('get_runtime_metrics relay', JSON.stringify(runtimeMetricsResponses[0] || null));
   }
 
   stdout = '';


### PR DESCRIPTION
## Summary
This PR fixes issue #35 by replacing the current placeholder runtime-tool responses with real runtime-addon round-trips for the four affected live-inspection tools:

- `inspect_runtime_tree`
- `set_runtime_property`
- `call_runtime_method`
- `get_runtime_metrics`

It also adds integration-style bridge coverage so the regression is locked down at the protocol boundary where the bug actually occurred.

## Why this change is needed
Issue #35 showed a very specific mismatch between the repository's intended runtime-debug story and the server behavior that users were actually seeing:

1. the Godot runtime addon already supported the required commands (`get_tree`, `set_property`, `call_method`, `get_metrics`),
2. the server already had a shared runtime TCP command path, and
3. the affected MCP tools were still returning stub payloads, process logs, or `not_implemented` placeholders instead of relaying addon data.

In other words, the runtime transport already existed, but these higher-level tools never crossed the last mile into the real addon command path.

That made the feature appear available while silently degrading into fallback/debug output. For live debugging workflows, that is worse than a clean error because it gives the user something that looks structured but is not the runtime truth.

## Direction and prior history considered
I checked the recent runtime direction before making this change.

Relevant earlier commits already moved the project toward real addon-backed runtime verification rather than process-state guesses:

- `5271c5a` — runtime status connectivity check work
- `09783d6` — framed welcome/pong response handling for the runtime addon

Those changes established the pattern that runtime tools should trust the addon protocol once it is available.

This PR follows that same direction instead of adding another layer of placeholder logic. It extends the already-established runtime channel to the remaining tools that were still hard-coded to stubs.

## What changed
### 1. Replaced stub handlers with real runtime command relays
The affected handlers in `src/index.ts` now call the runtime addon directly instead of synthesizing placeholder payloads:

- `inspect_runtime_tree` -> `get_tree`
- `set_runtime_property` -> `set_property`
- `call_runtime_method` -> `call_method`
- `get_runtime_metrics` -> `get_metrics`

### 2. Kept the existing server contract shape focused
I did not introduce a new abstraction layer or a second transport path.

The change reuses the existing `handleRuntimeCommand(...)` flow that the repository already uses for runtime addon communication. That keeps the fix small, reversible, and aligned with the current implementation model.

### 3. Added regression coverage where the bug surfaced
`test-bridge.mjs` now exercises the real failing behaviors by mocking addon responses for the newly routed commands and asserting that the MCP tools return those runtime results instead of stubs.

That matters because this bug was not just a TypeScript-level issue; it was an end-to-end protocol mismatch between MCP tool handlers and the runtime addon.

## Why I chose this approach
I deliberately chose relay-through-existing-transport over adding more fallback formatting because:

- the addon already provides the authoritative data,
- the TCP runtime command path already exists and is used elsewhere,
- the issue report proved that direct addon access returns the expected payloads, and
- the cleanest fix is to remove the fake responses rather than make the fake responses more elaborate.

This keeps the fix honest: when the addon is present, users now get the addon's real data.

## Verification
I ran the following on the delivery branch:

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `GOPEAK_TEST_PROJECT=/home/yun/gopeak-demo node test-bridge.mjs`

Result:

- `test-bridge.mjs`: **41 passed, 0 failed**

The updated bridge test specifically confirmed that:

- `inspect_runtime_tree` relays runtime tree data
- `set_runtime_property` relays property updates
- `call_runtime_method` relays method results
- `get_runtime_metrics` relays addon metrics

## Risk / tradeoff notes
This change intentionally removes the old placeholder behavior. That is the goal, because the placeholder behavior was the bug.

The main behavior change is that these tools now depend on the runtime addon path for real answers, which is consistent with their advertised purpose.

If the addon is unavailable, the server still returns the existing connection/transport error path from the runtime command layer rather than fabricated pseudo-results.

## Files changed
- `src/index.ts`
- `test-bridge.mjs`

Closes #35.
