### PR TITLE
docs: remove expired Discord invite from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,13 @@
 [![](https://img.shields.io/github/last-commit/HaD0Yun/Gopeak-godot-mcp 'Last Commit')](https://github.com/HaD0Yun/Gopeak-godot-mcp/commits/main)
 [![](https://img.shields.io/github/stars/HaD0Yun/Gopeak-godot-mcp 'Stars')](https://github.com/HaD0Yun/Gopeak-godot-mcp/stargazers)
 [![](https://img.shields.io/github/forks/HaD0Yun/Gopeak-godot-mcp 'Forks')](https://github.com/HaD0Yun/Gopeak-godot-mcp/network/members)
-[![](https://img.shields.io/badge/Discord-Join%20Community-5865F2?style=flat&logo=discord&logoColor=white)](https://discord.gg/FPKn4Xp8)
 [![](https://img.shields.io/badge/License-MIT-red.svg 'MIT License')](https://opensource.org/licenses/MIT)
 
 ![GoPeak Hero](assets/gopeak-hero-v2.png)
 
 **GoPeak is an MCP server for Godot that lets AI assistants run, inspect, modify, and debug real projects end-to-end.**
 
-> Join the GoPeak Discord community: https://discord.gg/FPKn4Xp8
+> Discord community chat is temporarily unavailable while the invite link is refreshed. Please use GitHub Discussions in the meantime: https://github.com/HaD0Yun/Gopeak-godot-mcp/discussions
 
 ---
 


### PR DESCRIPTION
## Summary
This PR resolves issue #34 by removing the expired Discord invite from the README and replacing the public call-to-action with a temporary GitHub Discussions fallback until a verified Discord invite is available again.

## Why this change is needed
Issue #34 reported a simple but user-facing trust problem: the repository was still advertising a community invite that no longer worked.

I verified that the published invite code returned Discord API error `10006` (`Unknown Invite`). That means the current README was pointing users at a dead destination.

For onboarding and community links, a broken link is worse than no link because it creates needless friction at the exact moment a user is trying to engage with the project.

## Direction and prior history considered
I checked the prior documentation history before changing this.

Relevant earlier history:

- `0efa98c` — added the Discord community link to the README
- `e216149` — carried the Discord README update forward during later branch integration

So the existing README link was not accidental; it was a deliberate documentation choice. Because of that, I did not want to make a casual or speculative edit.

The new change follows the same documentation intent—help users find the community—but updates it to reflect the current reality instead of leaving a stale invite in place.

## Why I removed the invite instead of replacing it with another Discord link
I did **not** invent or guess a new Discord invite.

That was an intentional decision.

At the time of the fix, the repository and the issue thread did not provide a verified replacement invite, and publishing an unverified link would risk creating the same problem again immediately.

The safest honest behavior is:

1. stop advertising the dead invite,
2. avoid pretending we have a verified replacement when we do not, and
3. route users to a stable project-owned surface that already exists.

GitHub Discussions satisfies that requirement today, so the README now points users there as a temporary fallback while the Discord invite is refreshed.

## What changed
### 1. Removed the expired Discord badge/link from the README header
The header no longer advertises the dead invite.

### 2. Replaced the inline community callout with a temporary fallback message
The README now clearly tells users that Discord chat is temporarily unavailable and directs them to GitHub Discussions instead.

This keeps the README helpful without overstating the current state of the community link.

## Verification
I ran the following on the delivery branch:

- `npm ci`
- `npm run typecheck`
- `npm run build`
- `npm test`

Additional link validation:

- Discord invite API for `FPKn4Xp8` returned `{"message":"Unknown Invite","code":10006}`
- GitHub Discussions for the repository returned HTTP `200`
- README no longer contains the expired invite

## Risk / tradeoff notes
The only real tradeoff is that users temporarily lose a one-click Discord join action from the README.

That is acceptable because the previous one-click action was already broken. Replacing a broken call-to-action with an honest fallback improves user experience and reduces confusion.

Once a verified Discord invite exists again, that invite can be restored cleanly in a later docs-only update.

## Files changed
- `README.md`

Closes #34.
