### PR TITLE
Ignore benign Godot helper shutdown stderr in executeOperation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "gopeak",
-  "version": "2.3.6",
+  "version": "2.3.6-kuiper.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "gopeak",
-      "version": "2.3.6",
+      "version": "2.3.6-kuiper.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gopeak",
-  "version": "2.3.6",
+  "version": "2.3.6-kuiper.1",
   "mcpName": "io.github.HaD0Yun/gopeak",
   "description": "GoPeak — MCP server for Godot Engine with 110+ tools, compact/dynamic profiles, GDScript LSP, DAP debugger, screenshots, input injection, and CC0 asset search.",
   "type": "module",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1250,7 +1250,7 @@ class GodotServer {
 
       try {
         const { stdout, stderr } = await execAsync(cmd);
-        return { stdout, stderr };
+        return { stdout, stderr: this.sanitizeGodotStderr(stderr) };
       } finally {
         rmSync(paramsDir, { recursive: true, force: true });
       }
@@ -1260,7 +1260,7 @@ class GodotServer {
         const execError = error as Error & { stdout: string; stderr: string };
         return {
           stdout: execError.stdout,
-          stderr: execError.stderr,
+          stderr: this.sanitizeGodotStderr(execError.stderr),
         };
       }
 
@@ -2649,6 +2649,31 @@ class GodotServer {
     }
 
     return null;
+  }
+
+  private sanitizeGodotStderr(stderr: string): string {
+    if (!stderr) {
+      return stderr;
+    }
+
+    const ignoredPatterns = [
+      /WARNING: ObjectDB instances leaked at exit/i,
+      /at:\s+cleanup\s+\(core\/object\/object\.cpp:/i,
+      /ERROR:\s+\d+\s+resources still in use at exit/i,
+      /at:\s+clear\s+\(core\/io\/resource\.cpp:/i,
+    ];
+
+    const filteredLines = stderr
+      .split(/\r?\n/)
+      .filter((line) => {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          return false;
+        }
+        return !ignoredPatterns.some((pattern) => pattern.test(trimmed));
+      });
+
+    return filteredLines.join('\n').trim();
   }
 
   /**


### PR DESCRIPTION
## Summary
- ignore benign Godot helper shutdown stderr in `executeOperation`
- keep successful helper operations from being reported as failures
- publish the patched package as `2.3.6-kuiper.1`

## Problem
In real Godot projects, helper operations can succeed but still print shutdown cleanup messages to `stderr`, such as leaked `ObjectDB` instances or resources still in use at exit. The current logic treats any `stderr` output as an operation failure, which produces false negatives for ordinary MCP tools.

## Fix
- add `sanitizeGodotStderr(stderr)` in `src/index.ts`
- strip the known benign shutdown cleanup lines before higher-level error handling
- preserve real stderr output so actual failures still surface normally

## Validation
- `project-setting-get`
- `project-search`
- `class-info`
- `runtime-status`