### PR TITLE
Use file-backed runtime screenshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ CLI bin names:
 | `GODOT_BRIDGE_PORT` | Bridge/Visualizer HTTP+WS port override | `6505` |
 | `GOPEAK_BRIDGE_HOST` | Bridge/Visualizer bind host | `127.0.0.1` |
 | `GOPEAK_TOOLS_PAGE_SIZE` | Number of tools per `tools/list` page | `33` |
+| `GOPEAK_RUNTIME_TIMEOUT_MS` | Runtime addon command timeout in milliseconds | `10000` |
 | `DEBUG` | Enable server debug logs | `false` |
 | `LOG_MODE` | Recording mode: `lite` or `full` | `lite` |
 
@@ -224,6 +225,8 @@ CLI bin names:
 | `6006` | Godot DAP. |
 | `7777` | Runtime addon command socket. |
 
+Runtime screenshot tools (`capture_screenshot`, `capture_viewport`) use a GoPeak-managed temporary PNG file when the runtime addon supports `output_path`, then return normal MCP image content. Older runtime addons that do not receive an `output_path` continue to return inline base64 screenshots.
+
 ---
 
 ## Troubleshooting
@@ -233,6 +236,7 @@ CLI bin names:
 - **Need a hidden tool** → search with `tool.catalog` or activate a group with `tool.groups`.
 - **Project path invalid** → confirm `project.godot` exists.
 - **Runtime tools not working** → install/enable the runtime addon and check port `7777`.
+- **Runtime screenshots time out** → update the runtime addon so screenshot commands support the managed `output_path` flow. For slow runtime responses, raise `GOPEAK_RUNTIME_TIMEOUT_MS`; older addons may still time out on large inline base64 screenshots.
 - **Editor bridge disconnected** → stop duplicate `gopeak`/MCP servers that may already own bridge port `6505`; `get_editor_status` reports bridge startup errors such as `EADDRINUSE`.
 
 ---

--- a/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
+++ b/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
@@ -270,7 +270,23 @@ func _cmd_capture_screenshot(params: Dictionary) -> Dictionary:
 	var viewport = get_viewport()
 	if viewport == null:
 		return {"type": "error", "message": "No viewport available"}
+	return _capture_viewport_image(viewport, params)
+
+
+func _cmd_capture_viewport(params: Dictionary) -> Dictionary:
+	var viewport_path = String(params.get("viewportPath", params.get("viewport_path", "")))
+	if viewport_path.is_empty():
+		return _cmd_capture_screenshot(params)
 	
+	var node = get_tree().root.get_node_or_null(viewport_path)
+	if node == null:
+		return {"type": "error", "message": "Viewport not found: " + viewport_path}
+	if not node is Viewport:
+		return {"type": "error", "message": "Node is not a Viewport: " + viewport_path}
+	return _capture_viewport_image(node as Viewport, params)
+
+
+func _capture_viewport_image(viewport: Viewport, params: Dictionary) -> Dictionary:
 	var viewport_texture = viewport.get_texture()
 	if viewport_texture == null:
 		return {"type": "error", "message": "No viewport texture available"}
@@ -284,24 +300,36 @@ func _cmd_capture_screenshot(params: Dictionary) -> Dictionary:
 	if width > 0 and height > 0:
 		image.resize(width, height)
 	
-	var png_bytes = image.save_png_to_buffer()
-	if png_bytes.is_empty():
-		return {"type": "error", "message": "Failed to encode screenshot as PNG"}
-	
-	var base64_str = Marshalls.raw_to_base64(png_bytes)
+	var requested_path = String(params.get("output_path", params.get("outputPath", "")))
+	if requested_path.is_empty():
+		var png_bytes = image.save_png_to_buffer()
+		if png_bytes.is_empty():
+			return {"type": "error", "message": "Failed to encode screenshot as PNG"}
+
+		return {
+			"type": "screenshot",
+			"format": "png",
+			"encoding": "base64",
+			"width": image.get_width(),
+			"height": image.get_height(),
+			"data": Marshalls.raw_to_base64(png_bytes)
+		}
+
+	var screenshot_path = requested_path
+	if screenshot_path.begins_with("user://") or screenshot_path.begins_with("res://"):
+		screenshot_path = ProjectSettings.globalize_path(screenshot_path)
+	var save_error = image.save_png(screenshot_path)
+	if save_error != OK:
+		return {"type": "error", "message": "Failed to save screenshot as PNG: " + str(save_error)}
 	
 	return {
-		"type": "screenshot",
+		"type": "screenshot_file",
 		"format": "png",
-		"encoding": "base64",
+		"encoding": "file",
 		"width": image.get_width(),
 		"height": image.get_height(),
-		"data": base64_str
+		"path": screenshot_path
 	}
-
-
-func _cmd_capture_viewport(params: Dictionary) -> Dictionary:
-	return _cmd_capture_screenshot(params)
 
 
 func _cmd_inject_action(params: Dictionary) -> Dictionary:

--- a/src/index.ts
+++ b/src/index.ts
@@ -543,11 +543,21 @@ class GodotServer {
     const params = (args && typeof args === 'object') ? args as Record<string, unknown> : {};
     const RUNTIME_PORT = 7777;
     const RUNTIME_HOST = '127.0.0.1';
-    const TIMEOUT_MS = 10000;
+    const timeoutOverride = Number.parseInt(process.env.GOPEAK_RUNTIME_TIMEOUT_MS || '', 10);
+    const TIMEOUT_MS = Number.isInteger(timeoutOverride) && timeoutOverride > 0 ? timeoutOverride : 10000;
+    const expectsScreenshot = command === 'capture_screenshot' || command === 'capture_viewport';
+    const screenshotDir = expectsScreenshot ? mkdtempSync(join(tmpdir(), 'gopeak-runtime-screenshot-')) : null;
+    const screenshotPath = screenshotDir ? join(screenshotDir, 'capture.png') : null;
+    const runtimeParams = screenshotPath ? { ...params, output_path: screenshotPath } : params;
+    const cleanupScreenshotDir = () => {
+      if (screenshotDir) {
+        rmSync(screenshotDir, { recursive: true, force: true });
+      }
+    };
 
     return new Promise((resolve) => {
       const socket = createTcpConnection({ port: RUNTIME_PORT, host: RUNTIME_HOST }, () => {
-        const payload = JSON.stringify({ command, params, id: Date.now() });
+        const payload = JSON.stringify({ command, params: runtimeParams, id: Date.now() });
         socket.write(payload + '\n');
       });
 
@@ -559,6 +569,7 @@ class GodotServer {
         }
         resolved = true;
         socket.destroy();
+        cleanupScreenshotDir();
         resolve({
           content: [{ type: 'text', text: `Runtime command '${command}' timed out after ${TIMEOUT_MS}ms. Ensure the Godot game is running with the MCP runtime addon enabled.` }],
         });
@@ -572,7 +583,36 @@ class GodotServer {
         clearTimeout(timer);
         socket.destroy();
 
+        if (parsed.type === 'screenshot_file' && parsed.path) {
+          const returnedPath = String(parsed.path);
+          if (!screenshotPath || normalize(returnedPath) !== normalize(screenshotPath)) {
+            cleanupScreenshotDir();
+            resolve({
+              content: [{ type: 'text', text: `Rejected screenshot file path outside the GoPeak-managed capture path: '${returnedPath}'` }],
+            });
+            return;
+          }
+          try {
+            const imageData = readFileSync(screenshotPath).toString('base64');
+            cleanupScreenshotDir();
+            resolve({
+              content: [
+                { type: 'text', text: `Screenshot captured: ${parsed.width}x${parsed.height} ${parsed.format}` },
+                { type: 'image', data: imageData, mimeType: 'image/png' },
+              ],
+            });
+          } catch (error) {
+            cleanupScreenshotDir();
+            const message = error instanceof Error ? error.message : String(error);
+            resolve({
+              content: [{ type: 'text', text: `Failed to read screenshot file '${screenshotPath}': ${message}` }],
+            });
+          }
+          return;
+        }
+
         if (parsed.type === 'screenshot' && parsed.data) {
+          cleanupScreenshotDir();
           resolve({
             content: [
               { type: 'text', text: `Screenshot captured: ${parsed.width}x${parsed.height} ${parsed.format}` },
@@ -582,6 +622,7 @@ class GodotServer {
           return;
         }
 
+        cleanupScreenshotDir();
         resolve({
           content: [{ type: 'text', text: JSON.stringify(parsed, null, 2) }],
         });
@@ -629,7 +670,8 @@ class GodotServer {
         }
 
         if (parsedMessages.length > 0) {
-          const candidate = parsedMessages.find((message) => message?.type === 'screenshot' && message?.data)
+          const candidate = parsedMessages.find((message) => message?.type === 'screenshot_file' && message?.path)
+            ?? parsedMessages.find((message) => message?.type === 'screenshot' && message?.data)
             ?? parsedMessages.find((message) => message?.type === 'pong')
             ?? parsedMessages.find((message) => message?.type && message.type !== 'welcome')
             ?? null;
@@ -648,6 +690,7 @@ class GodotServer {
         clearTimeout(timer);
         const responseData = responseBuffer.toString('utf8').trim();
         resolved = true;
+        cleanupScreenshotDir();
         try {
           const parsed = JSON.parse(responseData);
           resolve({
@@ -666,6 +709,7 @@ class GodotServer {
         }
         resolved = true;
         clearTimeout(timer);
+        cleanupScreenshotDir();
         resolve({
           content: [{ type: 'text', text: `Failed to connect to Godot runtime addon at ${RUNTIME_HOST}:${RUNTIME_PORT}: ${error.message}. Ensure the game is running with the MCP runtime autoload enabled.` }],
         });

--- a/test-bridge.mjs
+++ b/test-bridge.mjs
@@ -5,6 +5,7 @@
  */
 import { spawn } from 'node:child_process';
 import { createServer } from 'node:net';
+import { writeFileSync } from 'node:fs';
 import { WebSocket } from 'ws';
 import { setTimeout as delay } from 'node:timers/promises';
 import process from 'node:process';
@@ -22,6 +23,7 @@ const GODOT_PATH = process.env.GODOT_PATH || '/home/doyun/Apps/godot-4.6-rc2/God
 const TEST_PROJECT = process.env.GOPEAK_TEST_PROJECT || '/home/doyun/gopeak-smoke-test';
 const RUNTIME_PORT = 7777;
 const OPENAI_COMPATIBLE_TOOL_NAME_PATTERN = /^[a-zA-Z0-9-]{1,128}$/;
+const ONE_PIXEL_PNG_BASE64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0r0AAAAASUVORK5CYII=';
 
 let passed = 0;
 let failed = 0;
@@ -472,11 +474,22 @@ async function main() {
               object_node_count: 42,
             },
           })}\n`);
-        } else if (request.command === 'capture_screenshot' || request.command === 'capture_viewport') {
+        } else if (request.command === 'capture_screenshot') {
           socket.write(`${JSON.stringify({
             type: 'screenshot',
             id: request.id,
-            data: 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO7Z0r0AAAAASUVORK5CYII=',
+            data: ONE_PIXEL_PNG_BASE64,
+            width: 1,
+            height: 1,
+            format: 'png',
+          })}\n`);
+        } else if (request.command === 'capture_viewport') {
+          const screenshotPath = request.params?.output_path || request.params?.outputPath;
+          writeFileSync(screenshotPath, Buffer.from(ONE_PIXEL_PNG_BASE64, 'base64'));
+          socket.write(`${JSON.stringify({
+            type: 'screenshot_file',
+            id: request.id,
+            path: screenshotPath,
             width: 1,
             height: 1,
             format: 'png',


### PR DESCRIPTION
## Why

Runtime screenshots currently return the full PNG as base64 inside a JSON response over the runtime TCP socket. For larger/native viewports, this can make `capture_screenshot` / `capture_viewport` time out even though other runtime commands like ping, tree inspection, metrics, and input injection work normally.

Increasing the timeout alone would only mask the issue; the screenshot transport would still depend on a large inline JSON payload.

## What changed

- The MCP server now provides a managed temporary `output_path` for screenshot runtime commands.
- The runtime addon writes the screenshot PNG to that path and returns a small `screenshot_file` response.
- The MCP server reads the PNG from that exact managed path, returns MCP image content, and cleans up the temp directory.
- The runtime addon remains backward-compatible: if no `output_path` is provided, it falls back to the existing inline base64 `screenshot` response.
- Added integration coverage for both inline and file-backed screenshot responses.
- Documented `GOPEAK_RUNTIME_TIMEOUT_MS` and screenshot timeout troubleshooting.

## Validation

Passed:

- `npm ci`
- `npm run test:regressions`
- `npm run test:integration`
- `npm run test:docs`
- `npm run test:dynamic-groups`
- `node test-metadata-consistency.mjs`
- `npm pack --dry-run --json --ignore-scripts`

Manual verification:

- Verified `capture_screenshot` returned a `1280x720` `image/png` through the file-backed path.

Local Windows notes:

- `npm run test:setup` failed because `test-setup-hooks.mjs` expects `.bashrc` to be created in the manual bash-hook scenario, but on Windows `setupShellHooks()` exits early based on `process.platform`.
- `npm run test:packaging` failed on this Windows/Node 24 setup with `spawnSync npm.cmd EINVAL`, but the direct `npm pack --dry-run --json --ignore-scripts` command succeeded and included the expected package files.