### PR TITLE
fix(benchmark): classify unmet requirements as skipped

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "test:smoke": "node scripts/smoke-test.mjs",
     "test:integration": "node test-bridge.mjs",
     "test:dynamic-groups": "node test-dynamic-groups.mjs",
-    "test:ci": "npm run test:security && npm run test:smoke",
+    "test:ci": "npm run test:security && npm run test:smoke && npm run test:benchmark",
     "ci": "npm run build && npm run typecheck && npm run test:ci",
     "prepare": "npm run build",
     "postinstall": "node -e \"try{require('child_process').execFileSync(process.execPath,['build/cli.js','setup','--silent'],{stdio:'ignore'})}catch{}\"",
@@ -31,7 +31,8 @@
     "inspector": "npx @modelcontextprotocol/inspector build/index.js",
     "pack": "npm pack --dry-run",
     "version:bump": "node scripts/bump-version.mjs",
-    "test:setup": "npm run build && node test-setup-hooks.mjs"
+    "test:setup": "npm run build && node test-setup-hooks.mjs",
+    "test:benchmark": "node test-benchmark-cli-vs-mcp.mjs"
   },
   "engines": {
     "node": ">=18"

--- a/scripts/benchmark/cli-vs-mcp-benchmark.mjs
+++ b/scripts/benchmark/cli-vs-mcp-benchmark.mjs
@@ -224,19 +224,42 @@ async function runMcpTask(task, mcp, projectPath) {
 function summarize(results) {
   const summary = {};
   for (const surface of ['cli', 'mcp']) {
-    const surfaceRuns = results.filter((entry) => entry.surface === surface && entry.ok);
-    if (surfaceRuns.length === 0) {
-      summary[surface] = { okRuns: 0 };
-      continue;
-    }
+    const surfaceRuns = results.filter((entry) => entry.surface === surface);
+    const successfulRuns = surfaceRuns.filter((entry) => entry.ok);
+    const skippedRuns = surfaceRuns.filter((entry) => entry.skipped);
     summary[surface] = {
-      okRuns: surfaceRuns.length,
-      medianDurationMs: median(surfaceRuns.map((entry) => entry.durationMs)),
-      medianInvocationCount: median(surfaceRuns.map((entry) => entry.invocationCount)),
-      medianInterfaceTokenEstimate: median(surfaceRuns.map((entry) => entry.interfaceTokenEstimate)),
+      okRuns: successfulRuns.length,
+      skippedRuns: skippedRuns.length,
     };
+    if (successfulRuns.length > 0) {
+      summary[surface].medianDurationMs = median(successfulRuns.map((entry) => entry.durationMs));
+      summary[surface].medianInvocationCount = median(successfulRuns.map((entry) => entry.invocationCount));
+      summary[surface].medianInterfaceTokenEstimate = median(successfulRuns.map((entry) => entry.interfaceTokenEstimate));
+    }
   }
   return summary;
+}
+
+async function detectCapabilities(mcp) {
+  const capabilities = {
+    editor_bridge: false,
+  };
+
+  try {
+    const { response } = await mcp.callTool('editor.status', {});
+    const text = response?.result?.content?.map((part) => part?.text || '').join('\n') || '';
+    const parsed = text ? JSON.parse(text) : {};
+    capabilities.editor_bridge = Boolean(parsed.connected);
+  } catch (error) {
+    capabilities.editor_bridge_error = error instanceof Error ? error.message : String(error);
+  }
+
+  return capabilities;
+}
+
+function getMissingRequirements(task, surface, capabilities) {
+  const required = task.requires?.[surface] || task.requires?.all || [];
+  return required.filter((requirement) => !capabilities[requirement]);
 }
 
 async function main() {
@@ -253,6 +276,7 @@ async function main() {
     GOPEAK_TOOL_PROFILE: matrix.baseline?.mcpProfile || 'compact',
   });
   await mcp.initialize();
+  const capabilities = await detectCapabilities(mcp);
 
   const runResults = [];
   try {
@@ -266,6 +290,28 @@ async function main() {
         for (const surface of ['cli', 'mcp']) {
           const fixture = ensureProjectCopy(sourceProjectPath, `${task.id}-${surface}-${iteration}`);
           try {
+            const missingRequirements = getMissingRequirements(task, surface, capabilities);
+            if (missingRequirements.length > 0) {
+              runResults.push({
+                taskId: task.id,
+                family: task.family,
+                label: task.label,
+                surface,
+                iteration,
+                projectPath: fixture.projectPath,
+                ok: false,
+                skipped: true,
+                skipReason: `missing capabilities: ${missingRequirements.join(', ')}`,
+                durationMs: 0,
+                invocationCount: 0,
+                interfaceTokenEstimate: 0,
+                stdout: '',
+                stderr: '',
+                assertionFailures: [],
+              });
+              continue;
+            }
+
             const surfaceResult = surface === 'cli'
               ? await runCliTask(task, fixture.projectPath, godotPath)
               : await runMcpTask(task, mcp, fixture.projectPath);
@@ -278,6 +324,7 @@ async function main() {
               iteration,
               projectPath: fixture.projectPath,
               ok: surfaceResult.ok && assertionFailures.length === 0,
+              skipped: false,
               durationMs: surfaceResult.durationMs,
               invocationCount: surfaceResult.invocationCount,
               interfaceTokenEstimate: surfaceResult.interfaceTokenEstimate,
@@ -315,6 +362,7 @@ async function main() {
     mcpProfile: matrix.baseline?.mcpProfile || 'compact',
     iterations,
     generatedAt: new Date().toISOString(),
+    capabilities,
     tasks: grouped,
   };
 

--- a/scripts/benchmark/cli-vs-mcp.matrix.json
+++ b/scripts/benchmark/cli-vs-mcp.matrix.json
@@ -13,6 +13,7 @@
       "family": "scene_script_mutation",
       "label": "Create scene",
       "setup": { "kind": "fresh_copy" },
+      "requires": { "mcp": ["editor_bridge"] },
       "cli": {
         "command": "scene-create",
         "args": {

--- a/test-benchmark-cli-vs-mcp.mjs
+++ b/test-benchmark-cli-vs-mcp.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { execFile as execFileCb } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFile = promisify(execFileCb);
+const repoRoot = resolve(new URL('.', import.meta.url).pathname);
+const benchmarkScript = join(repoRoot, 'scripts', 'benchmark', 'cli-vs-mcp-benchmark.mjs');
+const fixtureProject = process.env.GOPEAK_TEST_PROJECT || join(repoRoot, 'test-fixtures', 'benchmark-project');
+
+async function main() {
+  const tempRoot = await mkdtemp(join(tmpdir(), 'gopeak-benchmark-capabilities-'));
+  const projectCopy = join(tempRoot, 'benchmark-project');
+  const reportPath = join(tempRoot, 'benchmark-report.json');
+
+  try {
+    await execFile('cp', ['-R', fixtureProject, projectCopy], {
+      cwd: repoRoot,
+      maxBuffer: 1024 * 1024 * 20,
+    });
+
+    const { stdout } = await execFile(process.execPath, [
+      benchmarkScript,
+      '--projectPath', projectCopy,
+      '--tasks', 'scene_create',
+      '--iterations', '1',
+      '--output', reportPath,
+    ], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        GOPEAK_TOOL_PROFILE: 'compact',
+        GODOT_PATH: process.env.GODOT_PATH || 'godot',
+      },
+      maxBuffer: 1024 * 1024 * 20,
+    });
+
+    const report = JSON.parse(stdout);
+    const writtenReport = JSON.parse(await readFile(reportPath, 'utf8'));
+    assert.deepEqual(writtenReport, report, 'stdout report and --output report should match');
+
+    assert.equal(report.benchmark, 'gopeak-cli-vs-mcp');
+    assert.equal(report.capabilities.editor_bridge, false);
+    assert.equal(report.tasks.length, 1);
+
+    const [task] = report.tasks;
+    assert.equal(task.taskId, 'scene_create');
+    assert.equal(task.runs.length, 2);
+    assert.equal(task.summary.cli.okRuns, 1);
+    assert.equal(task.summary.cli.skippedRuns, 0);
+    assert.equal(task.summary.mcp.okRuns, 0);
+    assert.equal(task.summary.mcp.skippedRuns, 1);
+
+    const mcpRun = task.runs.find((run) => run.surface === 'mcp');
+    assert.equal(mcpRun.ok, false);
+    assert.equal(mcpRun.skipped, true);
+    assert.equal(mcpRun.skipReason, 'missing capabilities: editor_bridge');
+    assert.equal(mcpRun.invocationCount, 0);
+    assert.equal(mcpRun.interfaceTokenEstimate, 0);
+
+    console.log('benchmark capability skip regression checks passed');
+  } finally {
+    await rm(tempRoot, { recursive: true, force: true });
+  }
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.stack || error.message : String(error));
+  process.exit(1);
+});

--- a/test-fixtures/benchmark-project/project.godot
+++ b/test-fixtures/benchmark-project/project.godot
@@ -1,0 +1,8 @@
+; Engine configuration file.
+; Minimal fixture for GoPeak benchmark regression tests.
+
+config_version=5
+
+[application]
+config/name="GoPeak Benchmark Fixture"
+config/features=PackedStringArray("4.0")

--- a/test-fixtures/benchmark-project/scripts/player.gd
+++ b/test-fixtures/benchmark-project/scripts/player.gd
@@ -1,0 +1,4 @@
+extends Node
+
+func _ready() -> void:
+	pass


### PR DESCRIPTION
## Summary
- Port the focused PR #32 benchmark-methodology fix onto current `dev` without unrelated branch noise.
- Add benchmark capability detection and skipped/non-comparable run summaries for unmet runtime requirements.
- Mark MCP `scene_create` as requiring the editor bridge and add a repo-local regression fixture/test.

## Verification
- `npm run test:ci`
- `npm run typecheck`
- `npm run build`
- `npm run test:dynamic-groups`
- `git diff --check --cached`

## Notes
- GitHub showed no open PRs for this repo; this completes the still-actionable closed-unmerged #32 work from the live branch.
- `scene_create` skipped/non-comparable results should not be cited as CLI or MCP wins until editor-bridge parity is resolved.

## Ultragoal
- `.omx/ultragoal` local ledger: `G001-complete-the-actionable-unmerged-pr` complete with final quality gate APPROVE/CLEAR.
