### PR TITLE
fix(runtime): keep MCP runtime responsive while the game is paused

### DIFF
--- a/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
+++ b/src/addon/godot_mcp_runtime/mcp_runtime_autoload.gd
@@ -20,6 +20,13 @@ signal command_received(command: String, params: Dictionary)
 
 func _ready() -> void:
 	name = "MCPRuntime"
+	# The TCP control loop runs in _process (accept connections, poll clients, handle
+	# messages). With the default PROCESS_MODE_INHERIT that loop STOPS while the game tree
+	# is paused (get_tree().paused = true) — the runtime silently goes unreachable and the
+	# game can't even be un-paused over the socket. An introspection/debug server must stay
+	# responsive while the game is frozen, so it can inspect / capture / inject / resume a
+	# paused game; PROCESS_MODE_ALWAYS keeps _process running regardless of pause.
+	process_mode = Node.PROCESS_MODE_ALWAYS
 	_start_server()
 	print("[MCP Runtime] Autoload ready, server starting on port %d" % _port)
 


### PR DESCRIPTION
## Problem

The runtime addon's TCP control loop (accept connections / poll clients / handle
messages) runs in `_process`. With the default `PROCESS_MODE_INHERIT`, that loop
stops the moment the game tree is paused (`get_tree().paused = true`). The MCP
runtime then silently goes unreachable — and because the socket is dead, the game
can't even be un-paused over it.

That defeats the purpose of an introspection/debug server, whose whole value is
being able to inspect / capture / inject into / resume a *frozen* game. A common
case: pausing to hold a scene still for inspection or a screenshot leaves the
runtime dead.

## Fix

Set the `MCPRuntime` autoload to `PROCESS_MODE_ALWAYS` in `_ready()` so `_process`
keeps servicing the socket regardless of pause state. One line plus an explanatory
comment; no behavior change while unpaused.

## Testing

- `npm run build && npm run typecheck && npm run test:regressions` — green.
- Validated live: paused a running game and confirmed the runtime stayed reachable
  (inspect / capture / resume over the socket) where it previously went dead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
