### PR TITLE
feat: distribute GoPeak with Bun and GitHub Releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,30 +10,24 @@ on:
       - main
       - beta
 
+permissions:
+  contents: read
+
 jobs:
-  build-typecheck-smoke:
+  build-and-test:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        node-version: [18, 20]
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: ${{ matrix.node-version }}
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
         with:
           bun-version: 1.3.3
 
       - name: Restore Bun package cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
         with:
           path: ~/.bun/install/cache
           key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
@@ -46,80 +40,26 @@ jobs:
       - name: Build
         run: bun run build
 
-      - name: Verify selected Node runtime
-        run: node --version
-
-      - name: Probe built Node CLI
-        run: node build/cli.js --help
-
       - name: Typecheck
         run: bun run typecheck
 
-      - name: Smoke test
-        run: node scripts/smoke-test.mjs && node test-regressions.mjs && node test-godot-detection.mjs
+      - name: Runtime regression tests
+        run: bun run test:ci
+
+      - name: Dynamic groups test
+        run: bun run test:dynamic-groups
+
+      - name: Documentation policy tests
+        run: bun run test:docs
+
+      - name: Metadata consistency tests
+        run: bun run test:metadata
 
       - name: Packaging test
         run: bun run test:packaging
 
-  dynamic-groups-test:
-    runs-on: ubuntu-latest
-    needs: build-typecheck-smoke
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.3
-
-      - name: Restore Bun package cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
-
-      - name: Install dependencies
-        run: bun ci
-
-      - name: Dynamic groups test
-        run: node test-dynamic-groups.mjs
-
-  audit-production-deps:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: 1.3.3
-
-      - name: Restore Bun package cache
-        uses: actions/cache@v4
-        with:
-          path: ~/.bun/install/cache
-          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-bun-1.3.3-
-
-      - name: Install dependencies
-        run: bun ci
+      - name: Distribution archive and installer tests
+        run: bun run test:distribution
 
       - name: Audit production dependencies
         run: bun audit --prod

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,204 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions: {}
+
+jobs:
+  build_test:
+    if: github.repository == 'HaD0Yun/Doyunha-Gopeak'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+
+    steps:
+      - name: Checkout tag
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify release commit is on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags "https://github.com/${GITHUB_REPOSITORY}.git" main:refs/remotes/origin/main
+          release_commit="$(git rev-parse "${GITHUB_SHA}^{commit}")"
+          if ! git merge-base --is-ancestor "${release_commit}" origin/main; then
+            echo "Release commit ${release_commit} is not reachable from origin/main." >&2
+            exit 1
+          fi
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6
+        with:
+          bun-version: 1.3.3
+
+      - name: Restore Bun package cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: ~/.bun/install/cache
+          key: ${{ runner.os }}-bun-1.3.3-${{ hashFiles('bun.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-bun-1.3.3-
+
+      - name: Install dependencies
+        run: bun ci
+
+      - name: Verify tag and metadata versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          package_version="$(bun -e "console.log((await Bun.file('package.json').json()).version)")"
+          server_version="$(bun -e "console.log((await Bun.file('server.json').json()).version)")"
+          expected_tag="v${package_version}"
+
+          if [[ "${GITHUB_REF_NAME}" != "${expected_tag}" ]]; then
+            echo "Tag ${GITHUB_REF_NAME} does not match package version ${package_version}." >&2
+            exit 1
+          fi
+
+          if [[ "${server_version}" != "${package_version}" ]]; then
+            echo "server.json version ${server_version} does not match package version ${package_version}." >&2
+            exit 1
+          fi
+
+          echo "version=${package_version}" >> "${GITHUB_OUTPUT}"
+        id: version
+
+      - name: Build
+        run: bun run build
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Runtime regression tests
+        run: bun run test:ci
+
+      - name: Dynamic groups test
+        run: bun run test:dynamic-groups
+
+      - name: Documentation policy tests
+        run: bun run test:docs
+
+      - name: Metadata consistency tests
+        run: bun run test:metadata
+
+      - name: Packaging test
+        run: bun run test:packaging
+
+      - name: Distribution archive and installer tests
+        run: bun run test:distribution
+
+      - name: Audit production dependencies
+        run: bun audit --prod
+
+      - name: Verify clean source and build release assets
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [[ -n "$(git status --porcelain --untracked-files=all)" ]]; then
+            echo "Tests or build steps modified the checked-out release source." >&2
+            git status --short >&2
+            exit 1
+          fi
+
+          rm -rf dist
+          bun run release:pack
+
+          version="${{ steps.version.outputs.version }}"
+          archive="dist/gopeak-${version}.tgz"
+          checksum="${archive}.sha256"
+
+          if [[ ! -s "${archive}" || ! -s "${checksum}" ]]; then
+            echo "Release archive or checksum is missing or empty." >&2
+            exit 1
+          fi
+
+          expected_assets="$(printf '%s\n' "${archive}" "${checksum}")"
+          actual_assets="$(find dist -maxdepth 1 -type f -print | sort)"
+          if [[ "${actual_assets}" != "${expected_assets}" ]]; then
+            echo "dist contains stale or unexpected release assets." >&2
+            printf '%s\n' "${actual_assets}" >&2
+            exit 1
+          fi
+
+          (cd dist && sha256sum --check "$(basename "${checksum}")")
+
+          echo "archive=${archive}" >> "${GITHUB_OUTPUT}"
+          echo "checksum=${checksum}" >> "${GITHUB_OUTPUT}"
+        id: assets
+
+      - name: Upload release assets
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
+        with:
+          name: release-assets
+          path: |
+            ${{ steps.assets.outputs.archive }}
+            ${{ steps.assets.outputs.checksum }}
+          if-no-files-found: error
+          retention-days: 1
+
+  attest_release:
+    if: github.repository == 'HaD0Yun/Doyunha-Gopeak'
+    needs: build_test
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
+
+    steps:
+      - name: Download release assets
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
+        with:
+          name: release-assets
+          path: dist
+
+      - name: Verify downloaded release assets
+        id: assets
+        shell: bash
+        env:
+          VERSION: ${{ needs.build_test.outputs.version }}
+        run: |
+          set -euo pipefail
+          archive="dist/gopeak-${VERSION}.tgz"
+          checksum="${archive}.sha256"
+
+          expected_assets="$(printf '%s\n' "${archive}" "${checksum}")"
+          actual_assets="$(find dist -maxdepth 1 -type f -print | sort)"
+          if [[ "${actual_assets}" != "${expected_assets}" ]]; then
+            echo "Downloaded artifact contains unexpected release assets." >&2
+            printf '%s\n' "${actual_assets}" >&2
+            exit 1
+          fi
+
+          (cd dist && sha256sum --check "$(basename "${checksum}")")
+          echo "archive=${archive}" >> "${GITHUB_OUTPUT}"
+          echo "checksum=${checksum}" >> "${GITHUB_OUTPUT}"
+
+      - name: Attest release assets
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be
+        with:
+          subject-path: |
+            ${{ steps.assets.outputs.archive }}
+            ${{ steps.assets.outputs.checksum }}
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          VERSION: ${{ needs.build_test.outputs.version }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" \
+            "${{ steps.assets.outputs.archive }}" \
+            "${{ steps.assets.outputs.checksum }}" \
+            --verify-tag \
+            --generate-notes \
+            --title "GoPeak ${VERSION}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,15 @@ All notable changes to GoPeak (godot-mcp) will be documented in this file.
 ## [2.3.9] - 2026-07-13
 
 ### Fixed
-- Refreshed production dependency resolutions for `ws`, `hono`, and `qs` so the production npm audit gate passes again.
+- Refreshed production dependency resolutions for `ws`, `hono`, and `qs` so the production dependency audit gate passes again.
 - Kept the MCP registry metadata synchronized with the package release version.
+
+### Changed
+- Replaced registry-based CLI distribution with checksum-verified GitHub Release tarballs installed globally by Bun.
+- Updated current install, update, release, localized quick-start, and MCP metadata guidance for the GitHub Release flow.
+- Bundled the runtime so installation no longer resolves registry dependencies or needs registry credentials.
+- Kept the legacy installer flags `--dir`, `--godot`, and `--configure` as deprecated `2.3.x` compatibility options, with terminal-only config output and replacement guidance before their planned `3.0.0` removal.
+- Added GitHub artifact attestation alongside SHA-256 verification for release provenance.
 
 ## [2.3.7] - 2026-05-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,13 +7,13 @@ Thanks for contributing to GoPeak. This guide focuses on the current repository 
 - Search existing GitHub issues and pull requests before starting overlapping work.
 - Prefer small, reviewable changes over broad rewrites.
 - Keep user-visible behavior stable unless the change is explicitly intended to modify it.
-- When touching packaging or installation flows, preserve the current opt-in shell-hook behavior (`gopeak setup`) and avoid silent shell rc mutations during `npm install`.
+- When touching packaging or installation flows, preserve the current opt-in shell-hook behavior (`gopeak setup`) and avoid silent shell rc mutations during release installation.
 
 ## Development setup
 
 ```bash
-git clone https://github.com/HaD0Yun/Gopeak-godot-mcp.git
-cd Gopeak-godot-mcp
+git clone https://github.com/HaD0Yun/Doyunha-Gopeak.git
+cd Doyunha-Gopeak
 bun ci
 bun run build
 ```
@@ -22,7 +22,6 @@ Helpful commands:
 
 ```bash
 bun run watch              # TypeScript watch mode
-bun run inspector          # MCP inspector against build/index.js
 bun run test:setup         # Shell-hook regression checks
 ```
 
@@ -41,7 +40,7 @@ bun run test:setup         # Shell-hook regression checks
 ├── docs/                  # Architecture, roadmap, release docs
 ├── test-*.mjs             # Integration and regression coverage
 ├── server.json            # MCP registry metadata
-└── package.json           # npm metadata and scripts
+└── package.json           # Bun package metadata and scripts
 ```
 
 ## Expected workflow
@@ -49,7 +48,7 @@ bun run test:setup         # Shell-hook regression checks
 1. Make the smallest change that solves the problem.
 2. Reuse existing helpers and naming patterns before introducing new abstractions.
 3. Update docs when behavior, install flow, or capability claims change.
-4. Keep `package.json`, `server.json`, README claims, and release notes aligned when metadata changes.
+4. Keep `package.json`, `server.json`, README claims, GitHub Release assets, checksum/attestation guidance, and release notes aligned when metadata changes.
 
 ## Verification before PR
 

--- a/README-de.md
+++ b/README-de.md
@@ -10,19 +10,21 @@
 
 ### Anforderungen
 - Godot 4.x
-- Node.js 18+
+- Bun 1.3.3+
 - MCP-kompatibler Client
 
 ### Starten
 ```bash
-npx -y gopeak
-```
-
-oder:
-```bash
-npm install -g gopeak
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"
 gopeak
 ```
+
+Erst nach erfolgreicher Prüfsummenprüfung installiert Bun das Release-Archiv global. Linux verwendet `sha256sum`, macOS `shasum`.
+
+Die alten Installer-Optionen `--dir`, `--godot` und `--configure` bleiben während `2.3.x` mit Warnhinweis kompatibel und sollen in `3.0.0` entfernt werden. Die Zuordnung zum neuen Installationsort, Godot-Pfad und zur Client-Konfiguration steht in der [Migrationsrichtlinie](docs/migration-policy.md#bun-distribution-migration).
 
 ## Kurzüberblick
 - Vertrauenswürdige Kern-Tools + dynamische Tool-Gruppen bei Bedarf

--- a/README-ja.md
+++ b/README-ja.md
@@ -10,19 +10,21 @@
 
 ### 要件
 - Godot 4.x
-- Node.js 18+
+- Bun 1.3.3+
 - MCP 対応クライアント
 
 ### 実行
 ```bash
-npx -y gopeak
-```
-
-または:
-```bash
-npm install -g gopeak
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"
 gopeak
 ```
+
+チェックサムが一致した後、Bun がリリースファイルをグローバルにインストールします。Linux では `sha256sum`、macOS では `shasum` を使用します。
+
+旧インストーラーの `--dir`、`--godot`、`--configure` は `2.3.x` の間は警告付きで互換性が保たれ、`3.0.0` で削除される予定です。新しいインストール先、Godot パス、クライアント設定への対応は[移行ポリシー](docs/migration-policy.md#bun-distribution-migration)を参照してください。
 
 ## 要点
 - 信頼できる基本ツール + 必要時に有効化される動的ツールグループ

--- a/README-ko.md
+++ b/README-ko.md
@@ -10,27 +10,29 @@
 
 ### 요구사항
 - Godot 4.x
-- Node.js 18+
+- Bun 1.3.3+
 - MCP-compatible client
 
 ### 실행
 ```bash
-npx -y gopeak
-```
-
-또는:
-```bash
-npm install -g gopeak
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"
 gopeak
 ```
+
+체크섬이 일치해야 Bun이 릴리스 파일을 전역 설치합니다. Linux에서는 `sha256sum`, macOS에서는 `shasum`을 사용합니다.
+
+기존 설치기의 `--dir`, `--godot`, `--configure` 옵션은 `2.3.x` 동안 경고와 함께 호환되며 `3.0.0`에서 제거될 예정입니다. 새 설치 위치·Godot 경로·클라이언트 설정 방식은 [마이그레이션 정책](docs/migration-policy.md#bun-distribution-migration)을 확인하세요.
 
 ### MCP 설정 예시
 ```json
 {
   "mcpServers": {
     "godot": {
-      "command": "npx",
-      "args": ["-y", "gopeak"]
+      "command": "gopeak",
+      "args": []
     }
   }
 }

--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -10,19 +10,21 @@
 
 ### Requisitos
 - Godot 4.x
-- Node.js 18+
+- Bun 1.3.3+
 - Cliente compatível com MCP
 
 ### Executar
 ```bash
-npx -y gopeak
-```
-
-ou:
-```bash
-npm install -g gopeak
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"
 gopeak
 ```
+
+Após a verificação do checksum, o Bun instala o arquivo de release globalmente. No Linux, usa-se `sha256sum`; no macOS, `shasum`.
+
+As opções antigas `--dir`, `--godot` e `--configure` continuam aceitas com aviso durante a série `2.3.x` e serão removidas em `3.0.0`. Consulte a [política de migração](docs/migration-policy.md#bun-distribution-migration) para o mapeamento do local de instalação, caminho do Godot e configuração do cliente.
 
 ## Resumo
 - Ferramentas principais confiáveis + grupos dinâmicos ativados sob demanda

--- a/README-zh.md
+++ b/README-zh.md
@@ -10,19 +10,21 @@
 
 ### 要求
 - Godot 4.x
-- Node.js 18+
+- Bun 1.3.3+
 - 支持 MCP 的客户端
 
 ### 运行
 ```bash
-npx -y gopeak
-```
-
-或者：
-```bash
-npm install -g gopeak
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"
 gopeak
 ```
+
+校验和匹配后，Bun 才会全局安装该发布文件。Linux 使用 `sha256sum`，macOS 使用 `shasum`。
+
+旧安装器的 `--dir`、`--godot` 和 `--configure` 选项在 `2.3.x` 期间仍会被接受并显示警告，计划在 `3.0.0` 移除。安装位置、Godot 路径和客户端配置的新对应方式请参阅[迁移政策](docs/migration-policy.md#bun-distribution-migration)。
 
 ## 核心概览
 - 可信的核心工具 + 按需激活的动态工具组

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![](https://badge.mcpx.dev?type=server 'MCP Server')](https://modelcontextprotocol.io/introduction)
 [![Made with Godot](https://img.shields.io/badge/Made%20with-Godot-478CBF?style=flat&logo=godot%20engine&logoColor=white)](https://godotengine.org)
-[![](https://img.shields.io/badge/Node.js-339933?style=flat&logo=nodedotjs&logoColor=white 'Node.js')](https://nodejs.org/en/download/)
-[![npm](https://img.shields.io/npm/v/gopeak?style=flat&logo=npm&logoColor=white 'npm')](https://www.npmjs.com/package/gopeak)
+[![Bun](https://img.shields.io/badge/Bun-1.3.3%2B-f9f1e1?style=flat&logo=bun&logoColor=black 'Bun')](https://bun.sh/)
+[![GitHub Release](https://img.shields.io/github/v/release/HaD0Yun/Doyunha-Gopeak?style=flat&logo=github 'GitHub Release')](https://github.com/HaD0Yun/Doyunha-Gopeak/releases)
 [![](https://img.shields.io/badge/License-MIT-red.svg 'MIT License')](https://opensource.org/licenses/MIT)
 
 🌐 **Languages**: **English** | [한국어](README-ko.md) | [日本語](README-ja.md) | [Deutsch](README-de.md) | [Português](README-pt_BR.md) | [简体中文](README-zh.md)
@@ -16,7 +16,7 @@ It is designed for trusted Godot 4 workflows: small default tool surface, setup-
 
 > English is the canonical source of truth. Localized READMEs are concise overviews and may lag behind `README.md`.
 >
-> Discord is temporarily unavailable while the invite link is refreshed. Use [GitHub Discussions](https://github.com/HaD0Yun/Gopeak-godot-mcp/discussions) for now.
+> Discord is temporarily unavailable while the invite link is refreshed. Use [GitHub Discussions](https://github.com/HaD0Yun/Doyunha-Gopeak/discussions) for now.
 
 ---
 
@@ -25,21 +25,33 @@ It is designed for trusted Godot 4 workflows: small default tool surface, setup-
 ### Requirements
 
 - Godot 4.x
-- Node.js 18+
+- Bun 1.3.3+
 - MCP-compatible client such as Claude Desktop, Cursor, Cline, or OpenCode
 
-### 1) Run GoPeak
+### 1) Install GoPeak
 
 ```bash
-npx -y gopeak
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c gopeak-2.3.9.tgz.sha256
+else
+  shasum -a 256 -c gopeak-2.3.9.tgz.sha256
+fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"
 ```
 
-or install globally:
+This verifies the downloaded release before Bun installs it globally. The absolute tarball path avoids a relative-path bug in Bun 1.3.3. The checksum command works on Linux (`sha256sum`) and macOS (`shasum`). To use the supported installer instead, download or clone the repository and run it locally—do not pipe a remote script into a shell:
 
 ```bash
-npm install -g gopeak
-gopeak
+git clone https://github.com/HaD0Yun/Doyunha-Gopeak.git
+cd Doyunha-Gopeak
+./install.sh
 ```
+
+The release archive contains the bundled runtime. Installation and execution do not contact the npm registry or require npm credentials. For stronger provenance checking, release reviewers can also verify the GitHub artifact attestation as described in the [release process](docs/release-process.md).
+
+If you used the old installer, `--dir`, `--godot`, and `--configure` remain accepted with warnings through the `2.3.x` line and are planned for removal in `3.0.0`. The new mappings are: use Bun's global home (`BUN_INSTALL`) instead of a source checkout directory, put `GODOT_PATH` in the MCP client `env`, and use the configuration below instead of relying on installer output. During the compatibility window, `--godot` and `--configure` still print a client snippet but never write client files. See the [migration policy](docs/migration-policy.md#bun-distribution-migration) for the exact contract.
 
 ### 2) Add MCP client config
 
@@ -47,8 +59,8 @@ gopeak
 {
   "mcpServers": {
     "godot": {
-      "command": "npx",
-      "args": ["-y", "gopeak"],
+      "command": "gopeak",
+      "args": [],
       "env": {
         "GODOT_PATH": "/path/to/godot",
         "GOPEAK_TOOL_PROFILE": "compact"
@@ -99,13 +111,13 @@ Some capabilities require extra Godot-side services. GoPeak labels these instead
 Install from your Godot project folder:
 
 ```bash
-curl -sL https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main/install-addon.sh | bash
+curl -sL https://raw.githubusercontent.com/HaD0Yun/Doyunha-Gopeak/main/install-addon.sh | bash
 ```
 
 PowerShell:
 
 ```powershell
-iwr https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main/install-addon.ps1 -UseBasicParsing | iex
+iwr https://raw.githubusercontent.com/HaD0Yun/Doyunha-Gopeak/main/install-addon.ps1 -UseBasicParsing | iex
 ```
 
 Then enable plugins in **Project Settings → Plugins**:
@@ -119,7 +131,7 @@ Optional shell hooks for update notifications are opt-in:
 gopeak setup
 ```
 
-`gopeak setup` only modifies supported bash/zsh rc files when you run it explicitly. `npm install` does not install shell hooks automatically.
+`gopeak setup` only modifies supported bash/zsh rc files when you run it explicitly. Installing the release asset does not add shell hooks automatically.
 
 ---
 
@@ -177,18 +189,15 @@ Plain `{ "x": 100, "y": 200 }` and `[100, 200]` are also coerced for common `Vec
 ## Useful Commands
 
 ```bash
-# run from npm
-npx -y gopeak
-
-# install globally
-npm install -g gopeak
+# run the globally installed CLI
+gopeak
 
 # run from source
-git clone https://github.com/HaD0Yun/Gopeak-godot-mcp.git
-cd Gopeak-godot-mcp
+git clone https://github.com/HaD0Yun/Doyunha-Gopeak.git
+cd Doyunha-Gopeak
 bun ci
 bun run build
-node build/index.js
+bun run ./build/index.js
 
 # local verification
 bun run ci

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,8 +4,8 @@
 
 ## Current baseline (March 2026)
 
-- Package version: `2.3.4`
-- Distribution: npm package `gopeak`, MCP metadata in `server.json`
+- Package version: `2.3.9`
+- Distribution: bundled versioned GitHub Release tarball + SHA-256 checksum + provenance attestation, installed globally with Bun without install-time registry resolution; repository metadata in `server.json`
 - Default tool exposure: `compact` profile
 - Capability surface: 33 core tools + 22 dynamic groups (110+ tools total)
 - Additional MCP capabilities: resources are implemented, prompts are available, stdio remains the default transport

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -139,13 +139,13 @@ For any change that touches MCP capabilities or transport:
 2. **Schema checks**
    - Validate input/output schema compatibility for new/changed tools/resources/prompts.
 3. **Transport checks**
-   - Confirm stdio flow remains functional (`npx -y gopeak`, inspector/manual smoke).
+   - Confirm stdio flow remains functional (`gopeak` from a Bun-installed release asset, inspector/manual smoke).
    - For bridge-related changes, verify `/health`, websocket connection, and at least one tool round-trip.
 4. **Regression checks**
    - Keep compact profile discoverability (`tool.catalog`) working.
    - Confirm legacy aliases still resolve.
 5. **Release artifact checks**
-   - `bun run build` success and package metadata consistency (`package.json`, `server.json`).
+   - `bun run build` success, bundled release tarball/checksum/attestation validation, registry-free global installation, and metadata consistency (`package.json`, `server.json`).
 
 ---
 

--- a/docs/migration-policy.md
+++ b/docs/migration-policy.md
@@ -39,6 +39,20 @@ Every hide/remove/rename/API-contract change must be tracked with this row shape
 - Treat `intent_tracking` as a workflow layer, not a Godot engine primitive.
 - Require Godot 4 fixture evidence before promoting scene/resource/project-setting/tilemap mutation groups from audit-required to trusted.
 
+## Bun distribution migration
+
+The current CLI is a bundled runtime distributed as a versioned GitHub Release asset. It is not published to the npm registry, does not require registry credentials, and does not contact the npm registry while installing or running. Bun installs the already-built archive; it does not resolve runtime packages during installation.
+
+The previous source-checkout installer flags remain accepted with a deprecation warning throughout the `2.3.x` line. The new installer installs one verified global CLI rather than maintaining a source checkout. Compatibility configuration is printed to the terminal and never written to client files. The flags are planned for removal in `3.0.0`.
+
+| Old surface | New surface | Change type | Profile impact | Alias window | User workflow impact | Docs location | Verification |
+|---|---|---|---|---|---|---|---|
+| `--dir PATH` | Bun's global install location; set `BUN_INSTALL` before installation only when a custom Bun home is required. | `contract-change` | package metadata | Accepted with a warning in `2.3.x`; remove in `3.0.0`. | The installer no longer clones or updates a repository at `PATH`. | `README.md`, this section | `./install.sh --dir /tmp/legacy --help` reports the replacement without creating `/tmp/legacy`. |
+| `--godot PATH` | Put `GODOT_PATH` in the MCP client's `env` block. | `contract-change` | docs-only | Accepted with a warning in `2.3.x`; remove in `3.0.0`. | During `2.3.x`, the supplied path appears as `GODOT_PATH` in compatibility configuration output; the installer does not persist it. | `README.md` MCP config example | `./install.sh --godot /path/to/godot --configure claude` prints `GODOT_PATH` and writes no client file. |
+| `--configure NAME` | Use the client configuration example in `README.md` with `command: "gopeak"`. | `contract-change` | docs-only | Accepted with a warning and terminal-only config output in `2.3.x`; remove in `3.0.0`. | Supported client snippets remain printable during the window, but configuration stays user-managed. | `README.md` MCP config example | `./install.sh --configure claude` prints the supported snippet and writes no client file. |
+
+The checksum and provenance attestation protect different boundaries. SHA-256 detects a changed download. GitHub's artifact attestation identifies the repository and workflow that produced the archive. The supported installer checks SHA-256 before changing the global installation; release reviewers can additionally verify the attestation with the command in `docs/release-process.md`.
+
 ## Verification commands
 
 Run the relevant checks before publishing a migration claim:

--- a/docs/platform-roadmap.md
+++ b/docs/platform-roadmap.md
@@ -37,7 +37,7 @@ Ground truth from current repository:
 - Tools list and execution still function in compact and full profiles.
 - Existing resource URIs keep working (`godot://project/info`, `godot://scene/{path}`, etc.).
 - Prompt endpoints are discoverable and invocable from MCP clients that support prompts.
-- No breaking change to current `npx -y gopeak` startup and basic operations.
+- No breaking change to the globally installed `gopeak` startup and basic operations.
 
 ### Risks
 
@@ -92,7 +92,7 @@ Ground truth from current repository:
 
 1. Make platform evolution safe through repeatable verification.
 2. Protect backward compatibility (aliases, profiles, capability behavior).
-3. Improve release confidence for npm + MCP registry metadata.
+3. Improve release confidence for bundled GitHub Release assets, checksums, attestations, and MCP repository metadata.
 
 ### Candidate deliverables
 
@@ -104,7 +104,7 @@ Ground truth from current repository:
 
 - Every capability-affecting PR includes verification evidence.
 - Backward compatibility checks are run before version bumps.
-- Release artifacts (`build/`, `package.json`, `server.json`) are validated together.
+- Release artifacts (`gopeak-<version>.tgz`, its SHA-256 checksum, and provenance attestation), registry-free installation behavior, `package.json`, and `server.json` are validated together.
 
 ### Risks
 

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -1,51 +1,102 @@
 # Release Process
 
-This repository uses a simple bump -> verify -> tag -> publish flow.
+GoPeak releases use a bump → verify → package → tag → attest → publish flow. Each GitHub Release carries a versioned Bun-installable tarball and its SHA-256 checksum. The archive contains the bundled runtime and has no install-time registry dependencies.
 
 ## 1) Bump version
 
-Use the version sync script to update `package.json` + `server.json` (and versioned README references, if present):
+Use the version sync script to update `package.json` and `server.json`:
 
 ```bash
-node scripts/bump-version.mjs patch
-# or: node scripts/bump-version.mjs minor
-# or: node scripts/bump-version.mjs 2.3.0
+bun run version:bump -- patch
+# or: bun run version:bump -- minor
+# or: bun run version:bump -- 2.3.9
 ```
 
 Preview without writing:
 
 ```bash
-node scripts/bump-version.mjs patch --dry-run
+bun run version:bump -- patch --dry-run
 ```
+
+Then update the versioned release filenames and URLs in the current README, localized quick starts, website, and release notes. All of those references must match the new version before tagging.
 
 ## 2) Verify locally
 
-Run release checks before tagging:
+Run the release checks before packaging:
 
 ```bash
+bun ci
 bun run ci
 bun run test:dynamic-groups
 bun run test:integration
 bun run test:setup
+bun run test:docs
+bun run test:distribution
 ```
 
-## 3) Commit + tag
+## 3) Build the release assets
 
 ```bash
-git add package.json server.json README.md
-# plus any release notes/changelog edits
+bun run release:pack
+```
+
+For version `X.Y.Z`, the packaging task must create both files:
+
+- `dist/gopeak-X.Y.Z.tgz`
+- `dist/gopeak-X.Y.Z.tgz.sha256`
+
+Verify the checksum on Linux or macOS before tagging:
+
+```bash
+if command -v sha256sum >/dev/null 2>&1; then
+  (cd dist && sha256sum -c gopeak-X.Y.Z.tgz.sha256)
+else
+  (cd dist && shasum -a 256 -c gopeak-X.Y.Z.tgz.sha256)
+fi
+```
+
+The archive must install with `bun add -g "$PWD/dist/gopeak-X.Y.Z.tgz"` and expose both `gopeak` and `godot-mcp`. Use an absolute path because Bun 1.3.3 resolves a relative global tarball path from the wrong working directory. Installation must not contact the npm registry: the tarball contains the bundled runtime and its release package metadata has no runtime dependency ranges. `bun run test:packaging` checks the archive and an isolated registry-blocked global install of both binaries. `bun run test:distribution` adds installer and updater behavior. `bun run test:metadata` checks MCP startup against the built CLI; before publishing, also exercise the MCP handshake through an installed global binary.
+
+## 4) Commit and tag
+
+```bash
+git add package.json server.json README.md CHANGELOG.md
+# include the packaging script and other synchronized release files
 git commit -m "chore(release): vX.Y.Z"
 git tag vX.Y.Z
 git push origin main --tags
 ```
 
-## 4) Publish release
+The tag must exactly match the versions in `package.json` and `server.json`.
 
-- Publish to npm using existing publish flow (`npm publish` / CI release job if configured).
-- Create a GitHub Release from tag `vX.Y.Z`.
+## 5) Publish and verify the GitHub Release
+
+The tag-triggered release workflow builds and verifies the project, creates a GitHub artifact attestation for the tarball, then uploads the tarball and checksum to the matching GitHub Release. Confirm both assets are present and test installation from the public asset URL:
+
+```bash
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/vX.Y.Z/gopeak-X.Y.Z.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/vX.Y.Z/gopeak-X.Y.Z.tgz.sha256
+if command -v sha256sum >/dev/null 2>&1; then
+  sha256sum -c gopeak-X.Y.Z.tgz.sha256
+else
+  shasum -a 256 -c gopeak-X.Y.Z.tgz.sha256
+fi
+bun add -g "$PWD/gopeak-X.Y.Z.tgz"
+gopeak version
+```
+
+SHA-256 proves that the downloaded bytes match the release checksum. The attestation separately proves that GitHub Actions built those bytes for this repository. With GitHub CLI installed and authenticated, verify the downloaded archive before installation:
+
+```bash
+gh attestation verify gopeak-X.Y.Z.tgz --repo HaD0Yun/Doyunha-Gopeak
+```
+
+The shell installer performs the SHA-256 check automatically; attestation verification is a separate release-review step because the installer does not require GitHub CLI or GitHub authentication.
 
 ## Notes
 
-- Keep release changes focused (version metadata + release notes only).
-- `server.json` package version must always match `package.json`.
-- Keep npm metadata, MCP registry metadata, and README capability claims in sync when tool counts or install behavior change.
+- Keep release changes focused on synchronized metadata, release notes, packaging, and verification.
+- `server.json` describes the GitHub repository and installation website; an ordinary GitHub tarball is not represented as an MCP Registry package.
+- Do not upload an archive until its checksum, attestation, installed binaries, CLI version, and MCP startup have been verified.
+- Publishing and installation require no npm credentials, and installing the release must not contact the npm registry.
+- The Godot addon installers are separate from the GoPeak CLI release and remain documented in `README.md`.

--- a/index.html
+++ b/index.html
@@ -8,14 +8,14 @@
   <meta name="keywords" content="godot mcp, godot mcp server, model context protocol godot, godot ai, gopeak, godot engine ai, godot claude, godot cursor, godot game development ai, mcp server, godot tools, gdscript ai, godot automation">
   <meta name="author" content="HaD0Yun">
   <meta name="robots" content="index, follow">
-  <link rel="canonical" href="https://github.com/HaD0Yun/Gopeak-godot-mcp">
+  <link rel="canonical" href="https://github.com/HaD0Yun/Doyunha-Gopeak">
 
   <!-- Open Graph -->
   <meta property="og:title" content="GoPeak — MCP Server for Godot Engine">
   <meta property="og:description" content="The most comprehensive Model Context Protocol server for Godot Engine. 95+ tools for AI-assisted game development.">
-  <meta property="og:url" content="https://github.com/HaD0Yun/Gopeak-godot-mcp">
+  <meta property="og:url" content="https://github.com/HaD0Yun/Doyunha-Gopeak">
   <meta property="og:type" content="website">
-  <meta property="og:image" content="https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main/assets/gopeak-banner.png">
+  <meta property="og:image" content="https://raw.githubusercontent.com/HaD0Yun/Doyunha-Gopeak/main/assets/gopeak-banner.png">
 
   <!-- Twitter Card -->
   <meta name="twitter:card" content="summary_large_image">
@@ -30,7 +30,7 @@
     "name": "GoPeak",
     "alternateName": "godot-mcp",
     "description": "The most comprehensive Model Context Protocol (MCP) server for Godot Engine. 95+ tools for AI-assisted game development including scene management, GDScript LSP diagnostics, DAP debugger, screenshot capture, input injection, ClassDB introspection, and CC0 asset library.",
-    "url": "https://github.com/HaD0Yun/Gopeak-godot-mcp",
+    "url": "https://github.com/HaD0Yun/Doyunha-Gopeak",
     "applicationCategory": "DeveloperApplication",
     "operatingSystem": "Windows, macOS, Linux",
     "offers": {
@@ -43,10 +43,10 @@
       "name": "HaD0Yun",
       "url": "https://github.com/HaD0Yun"
     },
-    "codeRepository": "https://github.com/HaD0Yun/Gopeak-godot-mcp",
+    "codeRepository": "https://github.com/HaD0Yun/Doyunha-Gopeak",
     "programmingLanguage": ["TypeScript", "GDScript"],
-    "runtimePlatform": "Node.js",
-    "softwareRequirements": "Godot Engine 4.2+, Node.js 18+"
+    "runtimePlatform": "Bun",
+    "softwareRequirements": "Godot Engine 4.2+, Bun 1.3.3+"
   }
   </script>
 
@@ -97,7 +97,7 @@
 <body>
   <div class="container">
     <h1><span>GoPeak</span></h1>
-    <p class="tagline">The most comprehensive MCP server for Godot Engine — 95+ tools for AI-assisted game development</p>
+    <p class="tagline">A trusted Godot 4 MCP workflow for editing, running, inspecting, and fixing real projects</p>
 
     <div class="stats">
       <div class="stat">
@@ -115,15 +115,17 @@
     </div>
 
     <div class="cta">
-      <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp" class="btn btn-primary">View on GitHub</a>
-      <a href="https://www.npmjs.com/package/gopeak" class="btn btn-secondary">npm: gopeak</a>
+      <a href="https://github.com/HaD0Yun/Doyunha-Gopeak" class="btn btn-primary">View on GitHub</a>
+      <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/releases" class="btn btn-secondary">GitHub Releases</a>
     </div>
 
     <div class="install">
       <h2>Quick Install</h2>
-      <pre><code>npx gopeak@latest</code></pre>
-      <p style="color:#8b949e; margin-top:8px;">Or install globally:</p>
-      <pre><code>npm install -g gopeak</code></pre>
+      <pre><code>curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
+if command -v sha256sum &gt;/dev/null 2&gt;&amp;1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi
+bun add -g "$PWD/gopeak-2.3.9.tgz"</code></pre>
+      <p style="color:#8b949e; margin-top:8px;">Requires Bun 1.3.3+. The archive includes the bundled runtime, so installation needs no registry credentials or install-time dependency download. Verify the checksum before installing; release reviewers can also verify the GitHub artifact attestation.</p>
     </div>
 
     <div class="features">
@@ -172,17 +174,17 @@
     <div style="margin-bottom:40px;">
       <h2 style="margin-bottom:16px;">Documentation</h2>
       <p style="color:#8b949e;">
-        📖 <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp#readme" style="color:#478cbf;">English</a> ·
-        <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp/blob/main/README-ko.md" style="color:#478cbf;">한국어</a> ·
-        <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp/blob/main/README-zh.md" style="color:#478cbf;">中文</a> ·
-        <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp/blob/main/README-ja.md" style="color:#478cbf;">日本語</a> ·
-        <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp/blob/main/README-de.md" style="color:#478cbf;">Deutsch</a> ·
-        <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp/blob/main/README-pt_BR.md" style="color:#478cbf;">Português</a>
+        📖 <a href="https://github.com/HaD0Yun/Doyunha-Gopeak#readme" style="color:#478cbf;">English</a> ·
+        <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/blob/main/README-ko.md" style="color:#478cbf;">한국어</a> ·
+        <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/blob/main/README-zh.md" style="color:#478cbf;">中文</a> ·
+        <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/blob/main/README-ja.md" style="color:#478cbf;">日本語</a> ·
+        <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/blob/main/README-de.md" style="color:#478cbf;">Deutsch</a> ·
+        <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/blob/main/README-pt_BR.md" style="color:#478cbf;">Português</a>
       </p>
     </div>
 
     <footer>
-      <p>GoPeak is open source under the <a href="https://github.com/HaD0Yun/Gopeak-godot-mcp/blob/main/LICENSE">MIT License</a>.</p>
+      <p>GoPeak is open source under the <a href="https://github.com/HaD0Yun/Doyunha-Gopeak/blob/main/LICENSE">MIT License</a>.</p>
       <p style="margin-top:8px;">Made by <a href="https://github.com/HaD0Yun">HaD0Yun</a></p>
     </footer>
   </div>

--- a/install-addon.ps1
+++ b/install-addon.ps1
@@ -27,7 +27,7 @@ if (-not (Test-Path "addons")) {
     Write-Host "Created addons/ directory" -ForegroundColor Green
 }
 
-$repoUrl = "https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main"
+$repoUrl = "https://raw.githubusercontent.com/HaD0Yun/Doyunha-Gopeak/main"
 
 # Function to download a file
 function Download-File {
@@ -196,4 +196,4 @@ Write-Host "1. Open your project in Godot" -ForegroundColor White
 Write-Host "2. Go to Project > Project Settings > Plugins" -ForegroundColor White
 Write-Host "3. Enable the installed addon(s), especially godot_mcp_editor for bridge-backed tools" -ForegroundColor White
 Write-Host ""
-Write-Host "For more info: https://github.com/HaD0Yun/Gopeak-godot-mcp" -ForegroundColor Gray
+Write-Host "For more info: https://github.com/HaD0Yun/Doyunha-Gopeak" -ForegroundColor Gray

--- a/install-addon.sh
+++ b/install-addon.sh
@@ -4,7 +4,7 @@
 # Installs Auto Reload, Editor Bridge, and Runtime addons to your Godot project
 #
 # Usage: Run this script in your Godot project folder
-#   curl -sL https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main/install-addon.sh | bash
+#   curl -sL https://raw.githubusercontent.com/HaD0Yun/Doyunha-Gopeak/main/install-addon.sh | bash
 #
 
 set -e
@@ -16,7 +16,7 @@ CYAN='\033[0;36m'
 NC='\033[0m'
 BOLD='\033[1m'
 
-REPO_URL="https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main"
+REPO_URL="https://raw.githubusercontent.com/HaD0Yun/Doyunha-Gopeak/main"
 
 AUTO_RELOAD_ONLY=false
 RUNTIME_ONLY=false
@@ -225,4 +225,4 @@ echo "  1. Open your project in Godot"
 echo "  2. Go to Project > Project Settings > Plugins"
 echo "  3. Enable the installed addon(s), including ${BOLD}godot_mcp_editor${NC} for bridge-backed tools"
 echo ""
-echo "For more info: https://github.com/HaD0Yun/Gopeak-godot-mcp"
+echo "For more info: https://github.com/HaD0Yun/Doyunha-Gopeak"

--- a/install.sh
+++ b/install.sh
@@ -1,340 +1,247 @@
-#!/bin/bash
-#
-# Godot MCP Installer for Linux/macOS
-# One-click installation script
-#
-# Usage:
-#   curl -sL https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main/install.sh | bash
-#
-# Options:
-#   -d, --dir PATH      Installation directory (default: ~/.local/share/godot-mcp)
-#   -g, --godot PATH    Path to Godot executable
-#   -c, --configure     Show configuration for AI assistants
-#   -h, --help          Show help message
-#
+#!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-BLUE='\033[0;34m'
-CYAN='\033[0;36m'
-NC='\033[0m' # No Color
-BOLD='\033[1m'
-
-# Default values
-INSTALL_DIR="${HOME}/.local/share/godot-mcp"
+readonly REPOSITORY="HaD0Yun/Doyunha-Gopeak"
+readonly API_URL="https://api.github.com/repos/${REPOSITORY}/releases/latest"
+readonly MAX_ARCHIVE_BYTES=134217728
+readonly MAX_CHECKSUM_BYTES=4096
+VERSION=""
 GODOT_PATH=""
 SHOW_CONFIGURE=""
 
-# Parse arguments
-while [[ $# -gt 0 ]]; do
-    case $1 in
-        -d|--dir)
-            INSTALL_DIR="$2"
-            shift 2
-            ;;
-        -g|--godot)
-            GODOT_PATH="$2"
-            shift 2
-            ;;
-        -c|--configure)
-            SHOW_CONFIGURE="$2"
-            shift 2
-            ;;
-        -h|--help)
-            echo "Godot MCP Installer"
-            echo ""
-            echo "Usage: install.sh [OPTIONS]"
-            echo ""
-            echo "Options:"
-            echo "  -d, --dir PATH        Installation directory (default: ~/.local/share/godot-mcp)"
-            echo "  -g, --godot PATH      Path to Godot executable"
-            echo "  -c, --configure NAME  Show config for: claude, cursor, cline, opencode"
-            echo "  -h, --help            Show this help message"
-            exit 0
-            ;;
-        *)
-            echo "Unknown option: $1"
-            exit 1
-            ;;
-    esac
-done
+usage() {
+  cat <<'EOF'
+GoPeak installer (Bun + GitHub Releases)
 
-# Banner
-echo -e "${CYAN}"
-echo "====================================="
-echo "     Godot MCP Installer"
-echo "     Linux / macOS"
-echo "====================================="
-echo -e "${NC}"
+Usage: install.sh [--version VERSION]
 
-# Function to print status
-print_status() {
-    echo -e "${BLUE}[*]${NC} $1"
+Options:
+  --version VERSION       Install an exact release (for example: 2.3.9)
+  -d, --dir PATH          Deprecated: accepted through 2.3.x; Bun owns the global install prefix
+  -g, --godot PATH        Deprecated: include GODOT_PATH in printed MCP configuration
+  -c, --configure CLIENT  Deprecated: print config for claude, cursor, cline, or opencode
+  -h, --help              Show this help
+
+Legacy flags are removed in GoPeak 3.0. Set BUN_INSTALL before running this
+installer if you need a custom Bun installation prefix.
+EOF
 }
 
-print_success() {
-    echo -e "${GREEN}[✓]${NC} $1"
+fail() {
+  printf 'Error: %s\n' "$1" >&2
+  exit 1
 }
 
-print_warning() {
-    echo -e "${YELLOW}[!]${NC} $1"
+deprecation() {
+  printf 'Deprecated: %s is accepted through GoPeak 2.3.x and will be removed in 3.0. %s\n' "$1" "$2" >&2
 }
 
-print_error() {
-    echo -e "${RED}[✗]${NC} $1"
-}
-
-# Check prerequisites
-check_prerequisites() {
-    print_status "Checking prerequisites..."
-    
-    # Check git
-    if ! command -v git &> /dev/null; then
-        print_error "Git is not installed. Please install git first."
-        echo "  Ubuntu/Debian: sudo apt install git"
-        echo "  Fedora: sudo dnf install git"
-        echo "  macOS: xcode-select --install"
-        exit 1
-    fi
-    print_success "Git found: $(git --version)"
-    
-    # Check Node.js
-    if ! command -v node &> /dev/null; then
-        print_error "Node.js is not installed. Please install Node.js 18+ first."
-        echo "  Visit: https://nodejs.org/en/download/"
-        echo "  Or use nvm: https://github.com/nvm-sh/nvm"
-        exit 1
-    fi
-    
-    NODE_VERSION=$(node -v | sed 's/v//' | cut -d. -f1)
-    if [ "$NODE_VERSION" -lt 18 ]; then
-        print_error "Node.js version 18+ required. Current version: $(node -v)"
-        exit 1
-    fi
-    print_success "Node.js found: $(node -v)"
-    
-    # Check npm
-    if ! command -v npm &> /dev/null; then
-        print_error "npm is not installed."
-        exit 1
-    fi
-    print_success "npm found: $(npm -v)"
-}
-
-# Detect Godot installation
-detect_godot() {
-    print_status "Detecting Godot installation..."
-    
-    if [ -n "$GODOT_PATH" ]; then
-        if [ -f "$GODOT_PATH" ]; then
-            print_success "Using specified Godot: $GODOT_PATH"
-            return
-        else
-            print_warning "Specified Godot path not found: $GODOT_PATH"
-        fi
-    fi
-    
-    # Common Godot executable names
-    GODOT_NAMES=("godot4" "godot" "godot-4" "Godot" "Godot_v4" "godot4.3" "godot4.2" "godot4.1")
-    
-    for name in "${GODOT_NAMES[@]}"; do
-        if command -v "$name" &> /dev/null; then
-            GODOT_PATH=$(command -v "$name")
-            print_success "Found Godot: $GODOT_PATH"
-            return
-        fi
+is_valid_version() {
+  local value="$1"
+  local without_build="${value%%+*}"
+  local build=""
+  if [[ "$value" == *+* ]]; then
+    build="${value#*+}"
+    [[ -n "$build" && "$build" != *..* && "$build" =~ ^[0-9A-Za-z.-]+$ ]] || return 1
+  fi
+  local core="${without_build%%-*}"
+  local prerelease=""
+  if [[ "$without_build" == *-* ]]; then
+    prerelease="${without_build#*-}"
+    [[ -n "$prerelease" ]] || return 1
+  fi
+  [[ "$core" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] || return 1
+  if [[ -n "$prerelease" ]]; then
+    [[ "$prerelease" != *..* && "$prerelease" =~ ^[0-9A-Za-z.-]+$ ]] || return 1
+    local identifier
+    local old_ifs="$IFS"
+    IFS='.'
+    for identifier in $prerelease; do
+      [[ -n "$identifier" ]] || { IFS="$old_ifs"; return 1; }
+      if [[ "$identifier" =~ ^[0-9]+$ && "$identifier" != "0" && "$identifier" == 0* ]]; then
+        IFS="$old_ifs"
+        return 1
+      fi
     done
-    
-    # Check common installation paths
-    GODOT_PATHS=(
-        "/usr/bin/godot4"
-        "/usr/bin/godot"
-        "/usr/local/bin/godot4"
-        "/usr/local/bin/godot"
-        "$HOME/.local/bin/godot4"
-        "$HOME/.local/bin/godot"
-        "/opt/godot/godot"
-        "/snap/bin/godot"
-        "/Applications/Godot.app/Contents/MacOS/Godot"
-        "$HOME/Applications/Godot.app/Contents/MacOS/Godot"
-    )
-    
-    for path in "${GODOT_PATHS[@]}"; do
-        if [ -f "$path" ]; then
-            GODOT_PATH="$path"
-            print_success "Found Godot: $GODOT_PATH"
-            return
-        fi
-    done
-    
-    # Check for Godot in Downloads (common for Linux)
-    if [ -d "$HOME/Downloads" ]; then
-        FOUND=$(find "$HOME/Downloads" -maxdepth 2 -name "Godot*" -type f -executable 2>/dev/null | head -n1)
-        if [ -n "$FOUND" ]; then
-            GODOT_PATH="$FOUND"
-            print_success "Found Godot in Downloads: $GODOT_PATH"
-            return
-        fi
-    fi
-    
-    print_warning "Godot not found automatically. You'll need to set GODOT_PATH manually."
-    GODOT_PATH=""
+    IFS="$old_ifs"
+  fi
 }
 
-# Clone or update repository
-install_repository() {
-    print_status "Installing Godot MCP to: $INSTALL_DIR"
-    
-    if [ -d "$INSTALL_DIR" ]; then
-        print_status "Directory exists. Updating..."
-        cd "$INSTALL_DIR"
-        git pull origin main
-    else
-        print_status "Cloning repository..."
-        mkdir -p "$(dirname "$INSTALL_DIR")"
-        git clone https://github.com/HaD0Yun/Gopeak-godot-mcp.git "$INSTALL_DIR"
-        cd "$INSTALL_DIR"
-    fi
-    
-    print_success "Repository ready"
+curl_secure() {
+  curl -fsSL \
+    --proto '=https' \
+    --proto-redir '=https' \
+    --connect-timeout 10 \
+    --max-time 120 \
+    --retry 2 \
+    --retry-all-errors \
+    "$@"
 }
 
-# Install dependencies and build
-build_project() {
-    print_status "Installing dependencies..."
-    cd "$INSTALL_DIR"
-    npm install
-    
-    print_status "Building project..."
-    npm run build
-    
-    print_success "Build complete"
+file_size() {
+  wc -c < "$1" | tr -d '[:space:]'
 }
 
-# Show configuration for AI assistants
-show_configuration() {
-    local build_path="$INSTALL_DIR/build/index.js"
-    local godot_env=""
-    
-    if [ -n "$GODOT_PATH" ]; then
-        godot_env="\"GODOT_PATH\": \"$GODOT_PATH\""
-    else
-        godot_env="\"GODOT_PATH\": \"/path/to/godot\""
-    fi
-    
-    echo ""
-    echo -e "${CYAN}====================================="
-    echo "  Configuration for AI Assistants"
-    echo -e "=====================================${NC}"
-    echo ""
-    
-    if [ "$SHOW_CONFIGURE" = "claude" ] || [ -z "$SHOW_CONFIGURE" ]; then
-        echo -e "${BOLD}Claude Desktop${NC} (claude_desktop_config.json):"
-        echo -e "${GREEN}"
-        cat << EOF
+download_verified_release() {
+  local version="$1"
+  local archive_path="$2"
+  local checksum_path="$3"
+  local asset="gopeak-${version}.tgz"
+  local release_base="https://github.com/${REPOSITORY}/releases/download/v${version}"
+  curl_secure --max-filesize "$MAX_ARCHIVE_BYTES" -o "$archive_path" "${release_base}/${asset}" \
+    || fail "could not download ${asset}"
+  curl_secure --max-filesize "$MAX_CHECKSUM_BYTES" -o "$checksum_path" "${release_base}/${asset}.sha256" \
+    || fail "could not download ${asset}.sha256"
+  (( $(file_size "$archive_path") <= MAX_ARCHIVE_BYTES )) || fail "release archive exceeds the size limit"
+  (( $(file_size "$checksum_path") <= MAX_CHECKSUM_BYTES )) || fail "release checksum exceeds the size limit"
+
+  local expected
+  expected="$(awk 'NR == 1 { print $1 }' "$checksum_path")"
+  [[ "$expected" =~ ^[0-9a-fA-F]{64}$ ]] || fail "release checksum file is malformed"
+  local actual
+  if command -v sha256sum >/dev/null 2>&1; then
+    actual="$(sha256sum "$archive_path" | awk '{ print $1 }')"
+  elif command -v shasum >/dev/null 2>&1; then
+    actual="$(shasum -a 256 "$archive_path" | awk '{ print $1 }')"
+  else
+    fail "SHA-256 verification requires sha256sum or shasum"
+  fi
+  [[ "$(printf '%s' "$actual" | tr '[:upper:]' '[:lower:]')" == "$(printf '%s' "$expected" | tr '[:upper:]' '[:lower:]')" ]] \
+    || fail "checksum verification failed; the existing GoPeak installation was not changed"
+}
+
+print_configuration() {
+  local client="$1"
+  local escaped_godot
+  escaped_godot="$(printf '%s' "$GODOT_PATH" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+  case "$client" in
+    claude|cline)
+      cat <<EOF
 {
   "mcpServers": {
     "godot": {
-      "command": "node",
-      "args": ["$build_path"],
-      "env": {
-        $godot_env
-      }
+      "command": "gopeak",
+      "args": [],
+      "env": { "GODOT_PATH": "${escaped_godot}" }
     }
   }
 }
 EOF
-        echo -e "${NC}"
-    fi
-    
-    if [ "$SHOW_CONFIGURE" = "cline" ] || [ -z "$SHOW_CONFIGURE" ]; then
-        echo -e "${BOLD}Cline (VS Code)${NC}:"
-        echo -e "${GREEN}"
-        cat << EOF
-{
-  "mcpServers": {
-    "godot": {
-      "command": "node",
-      "args": ["$build_path"],
-      "env": {
-        $godot_env,
-        "DEBUG": "true"
-      },
-      "disabled": false
-    }
-  }
-}
-EOF
-        echo -e "${NC}"
-    fi
-    
-    if [ "$SHOW_CONFIGURE" = "cursor" ] || [ -z "$SHOW_CONFIGURE" ]; then
-        echo -e "${BOLD}Cursor${NC}:"
-        echo "  1. Go to Cursor Settings > Features > MCP"
-        echo "  2. Click + Add New MCP Server"
-        echo "  3. Name: godot, Type: command"
-        echo -e "  4. Command: ${GREEN}node $build_path${NC}"
-        echo ""
-    fi
-    
-    if [ "$SHOW_CONFIGURE" = "opencode" ] || [ -z "$SHOW_CONFIGURE" ]; then
-        echo -e "${BOLD}OpenCode${NC} (opencode.json):"
-        echo -e "${GREEN}"
-        cat << EOF
+      ;;
+    opencode)
+      cat <<EOF
 {
   "mcp": {
     "godot": {
       "type": "local",
-      "command": ["node", "$build_path"],
-      "enabled": true,
-      "environment": {
-        $godot_env
-      }
+      "command": ["gopeak"],
+      "environment": { "GODOT_PATH": "${escaped_godot}" }
     }
   }
 }
 EOF
-        echo -e "${NC}"
-    fi
+      ;;
+    cursor)
+      printf 'Cursor MCP command: gopeak\nEnvironment: GODOT_PATH=%s\n' "$GODOT_PATH"
+      ;;
+    *)
+      fail "unsupported --configure client: $client"
+      ;;
+  esac
 }
 
-# Main installation flow
-main() {
-    check_prerequisites
-    detect_godot
-    install_repository
-    build_project
-    
-    echo ""
-    echo -e "${GREEN}====================================="
-    echo "  Installation Complete!"
-    echo -e "=====================================${NC}"
-    echo ""
-    echo -e "Installation directory: ${BOLD}$INSTALL_DIR${NC}"
-    echo -e "Build output: ${BOLD}$INSTALL_DIR/build/index.js${NC}"
-    
-    if [ -n "$GODOT_PATH" ]; then
-        echo -e "Godot executable: ${BOLD}$GODOT_PATH${NC}"
-    else
-        echo -e "${YELLOW}Godot not found. Set GODOT_PATH in your AI assistant config.${NC}"
-    fi
-    
-    show_configuration
-    
-    echo ""
-    echo -e "${CYAN}Next steps:${NC}"
-    echo "  1. Copy the configuration above to your AI assistant"
-    echo "  2. Restart your AI assistant"
-    echo "  3. Start using Godot MCP!"
-    echo ""
-    echo "  For addon installation in your Godot project:"
-    echo -e "  ${GREEN}curl -sL https://raw.githubusercontent.com/HaD0Yun/Gopeak-godot-mcp/main/install-addon.sh | bash${NC}"
-    echo ""
-    echo "For more info: https://github.com/HaD0Yun/Gopeak-godot-mcp"
-}
+while (($# > 0)); do
+  case "$1" in
+    --version)
+      (($# >= 2)) || fail "--version requires a value"
+      VERSION="${2#v}"
+      shift 2
+      ;;
+    -d|--dir)
+      (($# >= 2)) || fail "$1 requires a value"
+      deprecation "--dir" "The checkout directory is ignored; set BUN_INSTALL for a custom Bun prefix."
+      shift 2
+      ;;
+    -g|--godot)
+      (($# >= 2)) || fail "$1 requires a value"
+      GODOT_PATH="$2"
+      deprecation "--godot" "GODOT_PATH is now supplied in your MCP client configuration."
+      shift 2
+      ;;
+    -c|--configure)
+      (($# >= 2)) || fail "$1 requires a value"
+      SHOW_CONFIGURE="$2"
+      deprecation "--configure" "Use the Bun configuration examples in the README."
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      fail "unknown option: $1"
+      ;;
+  esac
+done
 
-main
+command -v bun >/dev/null 2>&1 || fail "Bun is required. Install it from https://bun.sh"
+command -v curl >/dev/null 2>&1 || fail "curl is required to download the GitHub Release"
+
+if [[ -z "$VERSION" ]]; then
+  release_json="$(curl_secure --max-filesize 1048576 -H 'Accept: application/vnd.github+json' -H 'User-Agent: gopeak-installer' "$API_URL")" \
+    || fail "could not resolve the latest GitHub Release"
+  (( ${#release_json} <= 1048576 )) || fail "latest release response exceeds the size limit"
+  VERSION="$(printf '%s' "$release_json" | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' | head -n 1)"
+fi
+is_valid_version "$VERSION" || fail "invalid release version: ${VERSION:-<empty>}"
+
+CURRENT_VERSION=""
+if bun pm ls -g 2>/dev/null | grep -q 'gopeak@'; then
+  current_output="$(gopeak version 2>/dev/null)" || fail "existing GoPeak version could not be resolved; installation was not changed"
+  CURRENT_VERSION="$(printf '%s' "$current_output" | sed -n 's/.*v\([^[:space:]]*\).*/\1/p' | head -n 1)"
+  is_valid_version "$CURRENT_VERSION" || fail "existing GoPeak version is malformed; installation was not changed"
+  if [[ "$CURRENT_VERSION" == "$VERSION" ]]; then
+    printf 'GoPeak %s is already installed; no changes were made.\n' "$VERSION"
+    if [[ -n "$SHOW_CONFIGURE" ]]; then
+      print_configuration "$SHOW_CONFIGURE"
+    elif [[ -n "$GODOT_PATH" ]]; then
+      print_configuration claude
+    fi
+    exit 0
+  fi
+fi
+
+TEMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEMP_DIR"' EXIT
+archive_path="${TEMP_DIR}/gopeak-${VERSION}.tgz"
+checksum_path="${archive_path}.sha256"
+
+printf 'Downloading GoPeak %s from GitHub Releases...\n' "$VERSION"
+download_verified_release "$VERSION" "$archive_path" "$checksum_path"
+
+rollback_archive=""
+if [[ -n "$CURRENT_VERSION" ]]; then
+  rollback_archive="${TEMP_DIR}/gopeak-${CURRENT_VERSION}.tgz"
+  download_verified_release "$CURRENT_VERSION" "$rollback_archive" "${rollback_archive}.sha256"
+
+  printf 'Checksums verified. Replacing the existing Bun installation...\n'
+  bun remove -g gopeak || fail "Bun could not remove the existing GoPeak release"
+  if ! bun add -g "$archive_path"; then
+    if bun add -g "$rollback_archive"; then
+      fail "Bun could not install GoPeak ${VERSION}; the previous release was restored"
+    fi
+    fail "Bun could not install GoPeak ${VERSION}, and rollback also failed"
+  fi
+else
+  printf 'Checksum verified. Installing with Bun...\n'
+  bun add -g "$archive_path" || fail "Bun could not install the verified GoPeak release"
+fi
+
+printf '\nGoPeak %s installed successfully.\n' "$VERSION"
+printf 'Shell notification hooks are optional; enable them manually with: gopeak setup\n'
+if [[ -n "$SHOW_CONFIGURE" ]]; then
+  print_configuration "$SHOW_CONFIGURE"
+elif [[ -n "$GODOT_PATH" ]]; then
+  print_configuration claude
+fi

--- a/package.json
+++ b/package.json
@@ -12,36 +12,35 @@
   },
   "files": [
     "build",
-    "scripts/postinstall.mjs",
     "README.md",
     "LICENSE"
   ],
   "scripts": {
-    "build": "tsc && node scripts/build-visualizer.js && node scripts/build.js",
-    "typecheck": "tsc --noEmit",
-    "test": "node scripts/smoke-test.mjs && node test-regressions.mjs && node test-godot-detection.mjs",
-    "smoke": "node scripts/smoke-test.mjs && node test-regressions.mjs && node test-godot-detection.mjs",
-    "test:smoke": "node scripts/smoke-test.mjs",
-    "test:integration": "node test-bridge.mjs",
-    "test:dynamic-groups": "node test-dynamic-groups.mjs",
-    "test:docs": "node test-readme-localization-consistency.mjs && node test-docs-package-policy.mjs",
-    "test:regressions": "node test-regressions.mjs",
-    "test:detection": "node test-godot-detection.mjs",
-    "test:ci": "node scripts/smoke-test.mjs && node test-regressions.mjs && node test-godot-detection.mjs",
-    "ci": "tsc && node scripts/build-visualizer.js && node scripts/build.js && tsc --noEmit && node scripts/smoke-test.mjs && node test-regressions.mjs && node test-godot-detection.mjs",
-    "prepare": "tsc && node scripts/build-visualizer.js && node scripts/build.js",
-    "postinstall": "node scripts/postinstall.mjs",
-    "watch": "tsc --watch",
-    "inspector": "npx @modelcontextprotocol/inspector build/index.js",
-    "pack": "npm pack --dry-run",
-    "version:bump": "node scripts/bump-version.mjs",
-    "test:setup": "tsc && node scripts/build-visualizer.js && node scripts/build.js && node test-setup-hooks.mjs && node test-metadata-consistency.mjs && node test-packaging-consistency.mjs",
-    "test:metadata": "tsc && node scripts/build-visualizer.js && node scripts/build.js && node test-metadata-consistency.mjs",
-    "test:packaging": "tsc && node scripts/build-visualizer.js && node scripts/build.js && node test-packaging-consistency.mjs",
-    "test:docs-policy": "node test-docs-package-policy.mjs"
+    "build": "bun scripts/build-release.mjs",
+    "typecheck": "bun node_modules/typescript/lib/tsc.js --noEmit",
+    "test": "bun scripts/smoke-test.mjs && bun test-regressions.mjs && bun test-godot-detection.mjs",
+    "smoke": "bun scripts/smoke-test.mjs && bun test-regressions.mjs && bun test-godot-detection.mjs",
+    "test:smoke": "bun scripts/smoke-test.mjs",
+    "test:integration": "bun test-bridge.mjs",
+    "test:dynamic-groups": "bun test-dynamic-groups.mjs",
+    "test:docs": "bun test-readme-localization-consistency.mjs && bun test-docs-package-policy.mjs",
+    "test:regressions": "bun test-regressions.mjs",
+    "test:detection": "bun test-godot-detection.mjs",
+    "test:ci": "bun scripts/smoke-test.mjs && bun test-regressions.mjs && bun test-godot-detection.mjs",
+    "ci": "bun run build && bun run typecheck && bun run test:ci",
+    "watch": "bun node_modules/typescript/lib/tsc.js --watch",
+    "pack": "bun run release:pack",
+    "release:pack": "bun run build && bun scripts/pack-release.mjs",
+    "version:bump": "bun scripts/bump-version.mjs",
+    "test:setup": "bun run release:pack && bun test-setup-hooks.mjs && bun test-metadata-consistency.mjs && bun test-packaging-consistency.mjs",
+    "test:metadata": "bun run build && bun test-metadata-consistency.mjs && bun test-version-bump.mjs",
+    "test:version-bump": "bun test-version-bump.mjs",
+    "test:packaging": "bun run release:pack && bun test-packaging-consistency.mjs && bun test-offline-release-install.mjs",
+    "test:distribution": "bun run release:pack && bun test-packaging-consistency.mjs && bun test-offline-release-install.mjs && bun test-bun-installer.mjs && bun test-github-update.mjs",
+    "test:docs-policy": "bun test-docs-package-policy.mjs"
   },
   "engines": {
-    "node": ">=18"
+    "bun": ">=1.3.3"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",
@@ -63,11 +62,11 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/HaD0Yun/Gopeak-godot-mcp.git"
+    "url": "git+https://github.com/HaD0Yun/Doyunha-Gopeak.git"
   },
-  "homepage": "https://github.com/HaD0Yun/Gopeak-godot-mcp#readme",
+  "homepage": "https://github.com/HaD0Yun/Doyunha-Gopeak#readme",
   "bugs": {
-    "url": "https://github.com/HaD0Yun/Gopeak-godot-mcp/issues"
+    "url": "https://github.com/HaD0Yun/Doyunha-Gopeak/issues"
   },
   "author": {
     "name": "HaD0Yun",

--- a/scripts/build-release.mjs
+++ b/scripts/build-release.mjs
@@ -1,0 +1,121 @@
+#!/usr/bin/env bun
+
+import { chmod, cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const sourceRoot = path.join(root, 'src');
+const buildRoot = path.join(root, 'build');
+
+async function buildBundledEntrypoint(sourceName, outputName) {
+  const result = await Bun.build({
+    entrypoints: [path.join(sourceRoot, sourceName)],
+    outdir: buildRoot,
+    naming: outputName,
+    // Bun supplies `ws` as a runtime compatibility module. Keeping Bun as the
+    // target preserves its working WebSocket server implementation on 1.3.3;
+    // embedding the npm `ws` package with `target: node` stalls WS upgrades.
+    target: 'bun',
+    format: 'esm',
+    bundle: true,
+    packages: 'bundle',
+    minify: false,
+    sourcemap: 'none',
+  });
+
+  if (result.success) return;
+
+  for (const log of result.logs) {
+    console.error(log);
+  }
+  throw new Error(`Bundling ${sourceName} failed`);
+}
+
+async function collectTypeScriptEntries(directory) {
+  const entries = [];
+  for (const item of await readdir(directory, { withFileTypes: true })) {
+    const itemPath = path.join(directory, item.name);
+    if (item.isDirectory()) {
+      entries.push(...await collectTypeScriptEntries(itemPath));
+    } else if (item.isFile() && item.name.endsWith('.ts')) {
+      entries.push(itemPath);
+    }
+  }
+  return entries;
+}
+
+await rm(buildRoot, { recursive: true, force: true });
+await mkdir(buildRoot, { recursive: true });
+
+await buildBundledEntrypoint('cli.ts', 'cli.js');
+await buildBundledEntrypoint('server-entry.ts', 'index.js');
+
+for (const sourcePath of await collectTypeScriptEntries(sourceRoot)) {
+  const relativePath = path.relative(sourceRoot, sourcePath);
+  if (relativePath === 'cli.ts' || relativePath === 'index.ts' || relativePath === 'server-entry.ts') continue;
+
+  const outputPath = path.join(buildRoot, relativePath.replace(/\.ts$/, '.js'));
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  const result = Bun.spawnSync([
+    process.execPath,
+    'build',
+    sourcePath,
+    `--outfile=${outputPath}`,
+    '--target=bun',
+    '--format=esm',
+    '--sourcemap=none',
+    '--no-bundle',
+  ], { cwd: root, stdout: 'pipe', stderr: 'pipe' });
+  if (result.exitCode !== 0) {
+    throw new Error(`Development module build failed for ${relativePath}:\n${result.stderr.toString().trim()}`);
+  }
+}
+
+const visualizerBuild = await Bun.build({
+  entrypoints: [path.join(sourceRoot, 'visualizer', 'main.js')],
+  target: 'browser',
+  format: 'iife',
+  bundle: true,
+  minify: false,
+  write: false,
+});
+if (!visualizerBuild.success) {
+  for (const log of visualizerBuild.logs) {
+    console.error(log);
+  }
+  throw new Error('Visualizer build failed');
+}
+
+const [template, css, bundledJavaScript] = await Promise.all([
+  readFile(path.join(sourceRoot, 'visualizer', 'template.html'), 'utf8'),
+  readFile(path.join(sourceRoot, 'visualizer', 'visualizer.css'), 'utf8'),
+  visualizerBuild.outputs[0].text(),
+]);
+await writeFile(
+  path.join(buildRoot, 'visualizer.html'),
+  template.replace('%%CSS%%', css).replace('%%SCRIPT%%', bundledJavaScript),
+  'utf8',
+);
+
+await mkdir(path.join(buildRoot, 'scripts'), { recursive: true });
+await cp(
+  path.join(sourceRoot, 'scripts', 'godot_operations.gd'),
+  path.join(buildRoot, 'scripts', 'godot_operations.gd'),
+);
+await cp(path.join(sourceRoot, 'addon'), path.join(buildRoot, 'addon'), { recursive: true });
+await writeFile(
+  path.join(buildRoot, 'godot-mcp.js'),
+  '#!/usr/bin/env bun\nimport \'./cli.js\';\n',
+  'utf8',
+);
+
+for (const executable of ['cli.js', 'godot-mcp.js', 'index.js']) {
+  const executablePath = path.join(buildRoot, executable);
+  const contents = await readFile(executablePath, 'utf8');
+  if (!contents.startsWith('#!/usr/bin/env bun\n')) {
+    await writeFile(executablePath, `#!/usr/bin/env bun\n${contents}`, 'utf8');
+  }
+  await chmod(executablePath, 0o755);
+}
+
+console.log(`Built dependency-free GoPeak runtime bundles with Bun ${Bun.version}`);

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 import fs from 'node:fs/promises';
 import path from 'node:path';
 import process from 'node:process';
@@ -6,10 +6,19 @@ import process from 'node:process';
 const ROOT = process.cwd();
 const PACKAGE_JSON_PATH = path.join(ROOT, 'package.json');
 const SERVER_JSON_PATH = path.join(ROOT, 'server.json');
-const README_PATH = path.join(ROOT, 'README.md');
+const VERSION_REFERENCE_PATHS = [
+  'README.md',
+  'README-de.md',
+  'README-ja.md',
+  'README-ko.md',
+  'README-pt_BR.md',
+  'README-zh.md',
+  'index.html',
+];
 const SEMVER_RE = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+const SEMVER_SOURCE = String.raw`\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?`;
 
-const usage = `Usage:\n  node scripts/bump-version.mjs <version|major|minor|patch> [--dry-run]\n\nExamples:\n  node scripts/bump-version.mjs patch\n  node scripts/bump-version.mjs 2.3.0 --dry-run`;
+const usage = `Usage:\n  bun scripts/bump-version.mjs <version|major|minor|patch> [--dry-run]\n\nExamples:\n  bun scripts/bump-version.mjs patch\n  bun scripts/bump-version.mjs 2.3.0 --dry-run`;
 
 function assertVersion(version) {
   if (!SEMVER_RE.test(version)) {
@@ -29,11 +38,13 @@ function bumpVersion(currentVersion, bumpType) {
   return `${major}.${minor}.${patch + 1}`;
 }
 
-function replaceVersionReferencesInReadme(content, nextVersion) {
+function replaceReleaseVersionReferences(content, nextVersion) {
   return content
-    .replace(/(npx\s+-y\s+gopeak@)(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)/g, `$1${nextVersion}`)
-    .replace(/(npm\s+install\s+-g\s+gopeak@)(\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?)/g, `$1${nextVersion}`)
-    .replace(/(https:\/\/raw\.githubusercontent\.com\/HaD0Yun\/godot-mcp\/v)(\d+\.\d+\.\d+)(\/install-addon\.(?:sh|ps1))/g, `$1${nextVersion}$3`);
+    .replace(
+      new RegExp(`(releases/download/v)${SEMVER_SOURCE}(/gopeak-)${SEMVER_SOURCE}(\\.tgz)`, 'g'),
+      `$1${nextVersion}$2${nextVersion}$3`,
+    )
+    .replace(new RegExp(`(gopeak-)${SEMVER_SOURCE}(\\.tgz(?:\\.sha256)?)`, 'g'), `$1${nextVersion}$2`);
 }
 
 async function readJson(filePath) {
@@ -82,21 +93,17 @@ async function main() {
 
   const server = await readJson(SERVER_JSON_PATH);
   server.version = nextVersion;
-  if (Array.isArray(server.packages)) {
-    for (const entry of server.packages) {
-      if (entry && typeof entry === 'object' && 'version' in entry) {
-        entry.version = nextVersion;
-      }
-    }
-  }
   await writeText(SERVER_JSON_PATH, `${JSON.stringify(server, null, 2)}\n`, dryRun);
   changed.push('server.json');
 
-  const readmeOriginal = await fs.readFile(README_PATH, 'utf8');
-  const readmeUpdated = replaceVersionReferencesInReadme(readmeOriginal, nextVersion);
-  if (readmeUpdated !== readmeOriginal) {
-    await writeText(README_PATH, readmeUpdated, dryRun);
-    changed.push('README.md');
+  for (const relativePath of VERSION_REFERENCE_PATHS) {
+    const filePath = path.join(ROOT, relativePath);
+    const original = await fs.readFile(filePath, 'utf8');
+    const updated = replaceReleaseVersionReferences(original, nextVersion);
+    if (updated !== original) {
+      await writeText(filePath, updated, dryRun);
+      changed.push(relativePath);
+    }
   }
 
   console.log(`${dryRun ? '[dry-run] ' : ''}Version bump ${currentVersion} -> ${nextVersion}`);

--- a/scripts/pack-release.mjs
+++ b/scripts/pack-release.mjs
@@ -1,0 +1,83 @@
+#!/usr/bin/env bun
+
+import { createHash } from 'node:crypto';
+import { cp, mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const sourcePackage = await Bun.file(path.join(root, 'package.json')).json();
+const outputDirectory = path.join(root, 'dist');
+const archiveName = `gopeak-${sourcePackage.version}.tgz`;
+const archivePath = path.join(outputDirectory, archiveName);
+const checksumPath = `${archivePath}.sha256`;
+const stagingRoot = await mkdtemp(path.join(os.tmpdir(), 'gopeak-release-pack-'));
+
+const releasePackage = {
+  name: sourcePackage.name,
+  version: sourcePackage.version,
+  mcpName: sourcePackage.mcpName,
+  description: sourcePackage.description,
+  type: sourcePackage.type,
+  main: sourcePackage.main,
+  bin: {
+    gopeak: 'build/cli.js',
+    'godot-mcp': 'build/godot-mcp.js',
+  },
+  engines: sourcePackage.engines,
+  license: sourcePackage.license,
+  repository: sourcePackage.repository,
+  homepage: sourcePackage.homepage,
+  bugs: sourcePackage.bugs,
+  author: sourcePackage.author,
+  funding: sourcePackage.funding,
+  keywords: sourcePackage.keywords,
+};
+
+try {
+  await rm(outputDirectory, { recursive: true, force: true });
+  await mkdir(outputDirectory, { recursive: true });
+  await mkdir(path.join(stagingRoot, 'build'), { recursive: true });
+
+  await Promise.all([
+    ...['cli.js', 'godot-mcp.js', 'index.js', 'visualizer.html'].map((name) =>
+      cp(path.join(root, 'build', name), path.join(stagingRoot, 'build', name))),
+    cp(path.join(root, 'build', 'addon'), path.join(stagingRoot, 'build', 'addon'), { recursive: true }),
+    cp(path.join(root, 'build', 'scripts'), path.join(stagingRoot, 'build', 'scripts'), { recursive: true }),
+    cp(path.join(root, 'README.md'), path.join(stagingRoot, 'README.md')),
+    cp(path.join(root, 'LICENSE'), path.join(stagingRoot, 'LICENSE')),
+    writeFile(
+      path.join(stagingRoot, 'package.json'),
+      `${JSON.stringify(releasePackage, null, 2)}\n`,
+      'utf8',
+    ),
+  ]);
+
+  const stagedArchive = path.join(stagingRoot, archiveName);
+  const pack = Bun.spawnSync([
+    process.execPath,
+    'pm',
+    'pack',
+    '--ignore-scripts',
+    '--filename',
+    stagedArchive,
+    '--quiet',
+  ], {
+    cwd: stagingRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  if (pack.exitCode !== 0) {
+    throw new Error(`bun pm pack failed:\n${pack.stderr.toString().trim()}`);
+  }
+
+  await rename(stagedArchive, archivePath);
+  const archive = await readFile(archivePath);
+  const checksum = createHash('sha256').update(archive).digest('hex');
+  await writeFile(checksumPath, `${checksum}  ${archiveName}\n`, 'utf8');
+} finally {
+  await rm(stagingRoot, { recursive: true, force: true });
+}
+
+console.log(path.relative(root, archivePath));
+console.log(path.relative(root, checksumPath));

--- a/server.json
+++ b/server.json
@@ -1,21 +1,11 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.HaD0Yun/gopeak",
-  "description": "GoPeak — MCP server for trusted Godot 4 workflows with compact/dynamic tool profiles, setup-gated LSP/DAP/runtime integrations, and migration-safe legacy compatibility.",
+  "description": "GoPeak — Bun-native MCP server for trusted Godot 4 workflows, automation, debugging, and editing.",
   "repository": {
-    "url": "https://github.com/HaD0Yun/Gopeak-godot-mcp",
+    "url": "https://github.com/HaD0Yun/Doyunha-Gopeak",
     "source": "github"
   },
-  "version": "2.3.9",
-  "packages": [
-    {
-      "registryType": "npm",
-      "identifier": "gopeak",
-      "version": "2.3.9",
-      "transport": {
-        "type": "stdio"
-      },
-      "runtimeHint": "npx"
-    }
-  ]
+  "websiteUrl": "https://github.com/HaD0Yun/Doyunha-Gopeak#readme",
+  "version": "2.3.9"
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 /**
  * GoPeak CLI Entrypoint
  *
@@ -18,13 +18,14 @@ import { getLocalVersion } from './cli/utils.js';
 const args = process.argv.slice(2);
 const command = args[0];
 
-const CLI_COMMANDS = ['setup', 'check', 'star', 'notify', 'uninstall', 'version', 'help', '--version', '-v', '--help', '-h'];
+const CLI_COMMANDS = ['setup', 'check', 'update', 'star', 'notify', 'uninstall', 'version', 'help', '--version', '-v', '--help', '-h'];
 
 async function main(): Promise<void> {
   // If no args or not a CLI command → start MCP server (original behavior)
   if (!command || !CLI_COMMANDS.includes(command)) {
     // Dynamic import to avoid loading MCP SDK for CLI-only commands
-    await import('./index.js');
+    const { runGodotServer } = await import('./index.js');
+    await runGodotServer();
     return;
   }
 
@@ -37,6 +38,11 @@ async function main(): Promise<void> {
     case 'check': {
       const { checkForUpdates } = await import('./cli/check.js');
       await checkForUpdates(args.slice(1));
+      break;
+    }
+    case 'update': {
+      const { updateGoPeak } = await import('./cli/update.js');
+      await updateGoPeak();
       break;
     }
     case 'star': {
@@ -80,6 +86,7 @@ Usage:
   gopeak check          Check for GoPeak updates
   gopeak check --bg     Background check (used by shell hooks)
   gopeak check --quiet  Print only if update available
+  gopeak update         Download, verify, and install the latest GitHub Release
   gopeak star           Star GoPeak on GitHub
   gopeak uninstall      Remove shell hooks
   gopeak version        Show current version
@@ -88,11 +95,11 @@ Usage:
 Shell hooks wrap these commands with update notifications:
   claude, codex, gemini, opencode, omc, omx
 
-More info: https://github.com/HaD0Yun/Gopeak-godot-mcp
+More info: https://github.com/HaD0Yun/Doyunha-Gopeak
 `.trim());
 }
 
-main().catch((err) => {
-  console.error('gopeak:', err.message ?? err);
+await main().catch((error: unknown) => {
+  console.error('gopeak:', error instanceof Error ? error.message : String(error));
   process.exit(1);
 });

--- a/src/cli/check.ts
+++ b/src/cli/check.ts
@@ -36,14 +36,14 @@ export async function checkForUpdates(args: string[]): Promise<void> {
 
   if (!latestVersion) {
     if (!isQuiet) {
-      console.log('⚠️  Could not reach npm registry. Check your network.');
+      console.log('⚠️  Could not reach GitHub Releases. Check your network.');
     }
     return;
   }
 
   if (compareSemver(latestVersion, currentVersion) > 0) {
     if (isQuiet) {
-      console.log(`🚀 GoPeak v${latestVersion} available! Run: npm update -g gopeak`);
+      console.log(`🚀 GoPeak v${latestVersion} available! Run: gopeak update`);
     } else {
       printUpdateBox(currentVersion, latestVersion);
     }
@@ -70,7 +70,7 @@ async function backgroundCheck(): Promise<void> {
   if (!latestVersion) return;
 
   if (compareSemver(latestVersion, currentVersion) > 0) {
-    const msg = `🚀 GoPeak v${latestVersion} available! (current: v${currentVersion})\n   Run: npm update -g gopeak`;
+    const msg = `🚀 GoPeak v${latestVersion} available! (current: v${currentVersion})\n   Run: gopeak update`;
     writeNotifyFile(msg);
   } else {
     // No update — clear stale notification if any
@@ -80,8 +80,8 @@ async function backgroundCheck(): Promise<void> {
 
 function printUpdateBox(current: string, latest: string): void {
   const line1 = `  🚀 GoPeak v${latest} available! (current: v${current})`;
-  const line2 = `  npm update -g gopeak`;
-  const line3 = `  https://github.com/HaD0Yun/Gopeak-godot-mcp/releases`;
+  const line2 = `  gopeak update`;
+  const line3 = `  https://github.com/HaD0Yun/Doyunha-Gopeak/releases`;
   const maxLen = Math.max(line1.length, line2.length, line3.length) + 2;
   const pad = (s: string) => s + ' '.repeat(Math.max(0, maxLen - s.length));
 

--- a/src/cli/notify.ts
+++ b/src/cli/notify.ts
@@ -5,7 +5,7 @@
  * Shows update prompt (y/n) and star prompt (y/n, one-time).
  */
 
-import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
+import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { createInterface } from 'readline';
 import {
   NOTIFY_FILE,
@@ -16,8 +16,10 @@ import {
   commandExists,
   runCommand,
 } from './utils.js';
+import { updateGoPeak } from './update.js';
 
-const REPO_URL = 'https://github.com/HaD0Yun/Gopeak-godot-mcp';
+const REPO = 'HaD0Yun/Doyunha-Gopeak';
+const REPO_URL = `https://github.com/${REPO}`;
 
 export async function showNotification(): Promise<void> {
   ensureGopeakDir();
@@ -41,16 +43,18 @@ export async function showNotification(): Promise<void> {
     const wantsUpdate = await askYesNo('  Update now? (y/n): ');
     if (wantsUpdate) {
       console.log('  Updating...');
-      const result = await runCommand('npm update -g gopeak');
-      if (result.code === 0) {
+      try {
+        await updateGoPeak();
         console.log('  ✅ Updated successfully!');
-      } else {
-        console.log('  ⚠️  Update failed. Run manually: npm update -g gopeak');
+      } catch (error: unknown) {
+        const message = error instanceof Error ? error.message : String(error);
+        console.log(`  ⚠️  Update failed: ${message}`);
+        console.log('  Run manually: gopeak update');
       }
     }
 
     // Remove notify file (shown once)
-    try { unlinkSync(NOTIFY_FILE); } catch { /* ignore */ }
+    rmSync(NOTIFY_FILE, { force: true });
     console.log('');
   }
 
@@ -72,20 +76,20 @@ async function handleStar(): Promise<void> {
     return;
   }
 
-  const authResult = await runCommand('gh auth status');
+  const authResult = await runCommand('gh', ['auth', 'status']);
   if (authResult.code !== 0) {
     console.log(`  ℹ️  gh not authenticated. Star directly: ${REPO_URL}`);
     return;
   }
 
   // Check if already starred
-  const checkResult = await runCommand('gh api user/starred/HaD0Yun/Gopeak-godot-mcp');
+  const checkResult = await runCommand('gh', ['api', `user/starred/${REPO}`]);
   if (checkResult.code === 0) {
     console.log('  ⭐ Already starred! Thank you!');
     return;
   }
 
-  const starResult = await runCommand('gh api -X PUT user/starred/HaD0Yun/Gopeak-godot-mcp');
+  const starResult = await runCommand('gh', ['api', '-X', 'PUT', `user/starred/${REPO}`]);
   if (starResult.code === 0) {
     console.log('  ⭐ Starred! Thank you for your support!');
   } else {

--- a/src/cli/setup.ts
+++ b/src/cli/setup.ts
@@ -81,7 +81,7 @@ export async function setupShellHooks(args: string[] = []): Promise<void> {
   const rcFile = getShellRcFile();
   const shellName = getShellName();
 
-  const log = silent ? (..._args: any[]) => {} : console.log.bind(console);
+  const log = silent ? (..._values: readonly unknown[]) => undefined : (...values: readonly unknown[]) => console.log(...values);
 
   // Check if RC file exists
   if (!existsSync(rcFile)) {
@@ -133,7 +133,7 @@ function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
 
-function printOnboarding(log: (...args: any[]) => void = console.log): void {
+function printOnboarding(log: (...values: readonly unknown[]) => void = console.log): void {
   const version = getLocalVersion();
   log('╔══════════════════════════════════════════════════════╗');
   log(`║  🎮 GoPeak v${version} — AI-Powered Godot Development`
@@ -141,9 +141,9 @@ function printOnboarding(log: (...args: any[]) => void = console.log): void {
   log('║                                                      ║');
   log('║  110+ tools for Godot Engine via MCP                 ║');
   log('║                                                      ║');
-  log('║  📖 Docs:   https://github.com/HaD0Yun/Gopeak-godot-mcp   ║');
+  log('║  📖 Docs:   https://github.com/HaD0Yun/Doyunha-Gopeak    ║');
   log('║  ⭐ Star:   gopeak star                              ║');
-  log('║  🔄 Update: npm update -g gopeak                     ║');
+  log('║  🔄 Update: gopeak update                            ║');
   log('╚══════════════════════════════════════════════════════╝');
   log('');
 }

--- a/src/cli/star.ts
+++ b/src/cli/star.ts
@@ -9,7 +9,7 @@
 import { commandExists, runCommand, STAR_PROMPTED_FILE, ensureGopeakDir } from './utils.js';
 import { existsSync, writeFileSync } from 'fs';
 
-const REPO = 'HaD0Yun/Gopeak-godot-mcp';
+const REPO = 'HaD0Yun/Doyunha-Gopeak';
 const REPO_URL = `https://github.com/${REPO}`;
 
 export async function starGoPeak(): Promise<void> {
@@ -23,7 +23,7 @@ export async function starGoPeak(): Promise<void> {
   }
 
   // 2. Check gh authentication
-  const authResult = await runCommand('gh auth status');
+  const authResult = await runCommand('gh', ['auth', 'status']);
   if (authResult.code !== 0) {
     console.log(`ℹ️  gh CLI is not authenticated.`);
     console.log(`   Please star GoPeak directly: ${REPO_URL}`);
@@ -32,7 +32,7 @@ export async function starGoPeak(): Promise<void> {
   }
 
   // 3. Check if already starred (REST: 204=starred, 404=not starred)
-  const checkResult = await runCommand(`gh api user/starred/${REPO}`);
+  const checkResult = await runCommand('gh', ['api', `user/starred/${REPO}`]);
   if (checkResult.code === 0) {
     console.log(`⭐ You've already starred GoPeak! Thank you!`);
     markStarPrompted();
@@ -40,7 +40,7 @@ export async function starGoPeak(): Promise<void> {
   }
 
   // 4. Star it (PUT user/starred/:owner/:repo)
-  const starResult = await runCommand(`gh api -X PUT user/starred/${REPO}`);
+  const starResult = await runCommand('gh', ['api', '-X', 'PUT', `user/starred/${REPO}`]);
   if (starResult.code === 0) {
     console.log(`⭐ Starred GoPeak! Thank you for your support!`);
   } else {

--- a/src/cli/update.ts
+++ b/src/cli/update.ts
@@ -1,0 +1,211 @@
+import { createHash, timingSafeEqual } from 'node:crypto';
+import { createWriteStream } from 'node:fs';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { get as httpsGet } from 'node:https';
+import type { IncomingMessage } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Transform } from 'node:stream';
+import type { TransformCallback } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { fetchLatestVersion, parseSemver, runCommand } from './utils.js';
+import type { CommandResult } from './utils.js';
+
+const REPOSITORY = 'HaD0Yun/Doyunha-Gopeak';
+const MAX_REDIRECTS = 5;
+const DOWNLOAD_TIMEOUT_MS = 30_000;
+const MAX_ARCHIVE_BYTES = 134_217_728;
+const MAX_CHECKSUM_BYTES = 4_096;
+
+type CommandRunner = (command: string, args: readonly string[]) => Promise<CommandResult>;
+
+type GlobalReplacement = {
+  readonly nextArchive: string;
+  readonly rollbackArchive?: string;
+};
+
+class ReleaseDownloadError extends Error {
+  readonly url: string;
+
+  constructor(message: string, url: string) {
+    super(message);
+    this.name = 'ReleaseDownloadError';
+    this.url = url;
+  }
+}
+
+export function assertSecureReleaseUrl(value: string | URL): URL {
+  const url = value instanceof URL ? value : new URL(value);
+  if (url.protocol !== 'https:') {
+    throw new ReleaseDownloadError('release downloads require HTTPS', url.href);
+  }
+  return url;
+}
+
+export function createDownloadLimiter(maxBytes: number): Transform {
+  let receivedBytes = 0;
+  return new Transform({
+    transform(chunk: Buffer, _encoding: BufferEncoding, callback: TransformCallback): void {
+      receivedBytes += chunk.byteLength;
+      if (receivedBytes > maxBytes) {
+        callback(new ReleaseDownloadError(`release download exceeded the ${maxBytes}-byte size limit`, 'response body'));
+        return;
+      }
+      callback(null, chunk);
+    },
+  });
+}
+
+function openReleaseUrl(url: URL, redirectsRemaining: number, maxBytes: number): Promise<IncomingMessage> {
+  const secureUrl = assertSecureReleaseUrl(url);
+  return new Promise((resolve, reject) => {
+    const outgoing = httpsGet(secureUrl, { headers: { 'User-Agent': 'gopeak-updater' } }, (response) => {
+      const status = response.statusCode ?? 0;
+      const location = response.headers.location;
+      if (status >= 300 && status < 400 && location) {
+        response.resume();
+        if (redirectsRemaining === 0) {
+          reject(new ReleaseDownloadError('too many release download redirects', secureUrl.href));
+          return;
+        }
+        let redirectUrl: URL;
+        try {
+          redirectUrl = assertSecureReleaseUrl(new URL(location, secureUrl));
+        } catch (error) {
+          reject(error);
+          return;
+        }
+        openReleaseUrl(redirectUrl, redirectsRemaining - 1, maxBytes).then(resolve, reject);
+        return;
+      }
+      if (status !== 200) {
+        response.resume();
+        reject(new ReleaseDownloadError(`release download returned HTTP ${status}`, secureUrl.href));
+        return;
+      }
+      const contentLength = response.headers['content-length'];
+      if (contentLength && Number(contentLength) > maxBytes) {
+        response.resume();
+        reject(new ReleaseDownloadError(`release download exceeded the ${maxBytes}-byte size limit`, secureUrl.href));
+        return;
+      }
+      resolve(response);
+    });
+    outgoing.setTimeout(DOWNLOAD_TIMEOUT_MS, () => {
+      outgoing.destroy(new ReleaseDownloadError('release download timed out', secureUrl.href));
+    });
+    outgoing.on('error', reject);
+  });
+}
+
+async function downloadFile(url: string, destination: string, maxBytes: number): Promise<void> {
+  const response = await openReleaseUrl(assertSecureReleaseUrl(url), MAX_REDIRECTS, maxBytes);
+  try {
+    await pipeline(
+      response,
+      createDownloadLimiter(maxBytes),
+      createWriteStream(destination, { flags: 'wx', mode: 0o600 }),
+    );
+  } catch (error) {
+    await rm(destination, { force: true });
+    throw error;
+  }
+}
+
+async function sha256(path: string): Promise<Buffer> {
+  const contents = await readFile(path);
+  return createHash('sha256').update(contents).digest();
+}
+
+async function downloadVerifiedRelease(version: string, temporaryDirectory: string): Promise<string> {
+  const asset = `gopeak-${version}.tgz`;
+  const releaseBase = `https://github.com/${REPOSITORY}/releases/download/v${version}`;
+  const archivePath = join(temporaryDirectory, asset);
+  const checksumPath = `${archivePath}.sha256`;
+  await downloadFile(`${releaseBase}/${asset}`, archivePath, MAX_ARCHIVE_BYTES);
+  await downloadFile(`${releaseBase}/${asset}.sha256`, checksumPath, MAX_CHECKSUM_BYTES);
+
+  const checksumText = await readFile(checksumPath, 'utf8');
+  const expectedText = checksumText.trim().split(/\s+/)[0] ?? '';
+  if (!/^[0-9a-fA-F]{64}$/.test(expectedText)) {
+    throw new ReleaseDownloadError('release checksum file is malformed', `${releaseBase}/${asset}.sha256`);
+  }
+  const expected = Buffer.from(expectedText, 'hex');
+  const actual = await sha256(archivePath);
+  if (!timingSafeEqual(actual, expected)) {
+    throw new ReleaseDownloadError('release checksum verification failed; existing installation was not changed', archivePath);
+  }
+  return archivePath;
+}
+
+export async function replaceGlobalPackage(
+  replacement: GlobalReplacement,
+  runner: CommandRunner = runCommand,
+): Promise<void> {
+  const removal = await runner('bun', ['remove', '-g', 'gopeak']);
+  if (removal.code !== 0) {
+    throw new ReleaseDownloadError(removal.stderr || 'Bun could not remove the existing release', replacement.nextArchive);
+  }
+  const installation = await runner('bun', ['add', '-g', replacement.nextArchive]);
+  if (installation.code === 0) return;
+  if (!replacement.rollbackArchive) {
+    throw new ReleaseDownloadError(installation.stderr || 'Bun could not install the verified release', replacement.nextArchive);
+  }
+  const rollback = await runner('bun', ['add', '-g', replacement.rollbackArchive]);
+  if (rollback.code === 0) {
+    throw new ReleaseDownloadError(
+      `${installation.stderr || 'Bun could not install the verified release'}; the previous release was restored`,
+      replacement.nextArchive,
+    );
+  }
+  throw new ReleaseDownloadError(
+    `${installation.stderr || 'Bun could not install the verified release'}; rollback also failed: ${rollback.stderr}`,
+    replacement.nextArchive,
+  );
+}
+
+async function getInstalledVersion(runner: CommandRunner): Promise<string | null> {
+  const globalPackages = await runner('bun', ['pm', 'ls', '-g']);
+  if (globalPackages.code !== 0 || !/(?:^|\s)gopeak@/m.test(globalPackages.stdout)) return null;
+  const current = await runner('gopeak', ['version']);
+  const currentVersionText = /\bv?([^\s]+)$/.exec(current.stdout)?.[1] ?? '';
+  const currentVersion = parseSemver(currentVersionText);
+  if (current.code !== 0 || !currentVersion) {
+    throw new ReleaseDownloadError('existing GoPeak version could not be resolved; installation was not changed', 'global installation');
+  }
+  return currentVersion.normalized;
+}
+
+export async function installRelease(version: string, runner: CommandRunner = runCommand): Promise<void> {
+  const parsedVersion = parseSemver(version);
+  if (!parsedVersion || parsedVersion.normalized !== version) {
+    throw new ReleaseDownloadError('release version is malformed', version);
+  }
+  const installedVersion = await getInstalledVersion(runner);
+  if (installedVersion === version) return;
+  const temporaryDirectory = await mkdtemp(join(tmpdir(), 'gopeak-update-'));
+  try {
+    const archivePath = await downloadVerifiedRelease(version, temporaryDirectory);
+    if (!installedVersion) {
+      const installation = await runner('bun', ['add', '-g', archivePath]);
+      if (installation.code !== 0) {
+        throw new ReleaseDownloadError(installation.stderr || 'Bun could not install the verified release', archivePath);
+      }
+      return;
+    }
+    const rollbackArchive = await downloadVerifiedRelease(installedVersion, temporaryDirectory);
+    await replaceGlobalPackage({ nextArchive: archivePath, rollbackArchive }, runner);
+  } finally {
+    await rm(temporaryDirectory, { recursive: true, force: true });
+  }
+}
+
+export async function updateGoPeak(): Promise<void> {
+  const version = await fetchLatestVersion();
+  if (!version) {
+    throw new ReleaseDownloadError('could not resolve the latest GitHub Release', 'GitHub Releases API');
+  }
+  console.log(`Downloading and verifying GoPeak v${version}...`);
+  await installRelease(version);
+  console.log(`✅ GoPeak v${version} installed successfully.`);
+}

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,23 +1,14 @@
-/**
- * GoPeak CLI Utilities
- * Shared helpers for version checking, caching, and shell detection.
- */
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { get as httpGet } from 'node:http';
+import { get as httpsGet } from 'node:https';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
 
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
-import { exec } from 'child_process';
-import { promisify } from 'util';
-import { fileURLToPath } from 'url';
-import { dirname } from 'path';
-import { get as httpsGet } from 'https';
-import { get as httpGet } from 'http';
-
-const execAsync = promisify(exec);
-
-/* ------------------------------------------------------------------ */
-/*  Paths                                                              */
-/* ------------------------------------------------------------------ */
+const LATEST_RELEASE_URL = 'https://api.github.com/repos/HaD0Yun/Doyunha-Gopeak/releases/latest';
+const MAX_RELEASE_RESPONSE_BYTES = 1_048_576;
+const VERSION_PATTERN = /^v?(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-((?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*)(?:\.(?:0|[1-9]\d*|\d*[A-Za-z-][0-9A-Za-z-]*))*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
 
 const GOPEAK_DIR = join(homedir(), '.gopeak');
 const LAST_CHECK_FILE = join(GOPEAK_DIR, 'last-check');
@@ -27,75 +18,174 @@ const STAR_PROMPTED_FILE = join(GOPEAK_DIR, 'star-prompted');
 
 export { GOPEAK_DIR, LAST_CHECK_FILE, NOTIFY_FILE, ONBOARDING_SHOWN_FILE, STAR_PROMPTED_FILE };
 
-export function ensureGopeakDir(): void {
-  if (!existsSync(GOPEAK_DIR)) {
-    mkdirSync(GOPEAK_DIR, { recursive: true });
-  }
-}
+type LatestVersionOptions = {
+  readonly url?: string;
+  readonly timeoutMs?: number;
+};
 
-/* ------------------------------------------------------------------ */
-/*  Version                                                            */
-/* ------------------------------------------------------------------ */
+type ParsedSemver = {
+  readonly major: number;
+  readonly minor: number;
+  readonly patch: number;
+  readonly prerelease: readonly string[];
+  readonly normalized: string;
+};
+
+export type CommandResult = {
+  readonly stdout: string;
+  readonly stderr: string;
+  readonly code: number;
+};
+
+export function ensureGopeakDir(): void {
+  if (!existsSync(GOPEAK_DIR)) mkdirSync(GOPEAK_DIR, { recursive: true });
+}
 
 export function getLocalVersion(): string {
-  try {
-    const __filename = fileURLToPath(import.meta.url);
-    const __dirname = dirname(__filename);
-    // Walk up from build/cli/utils.js → project root
-    const pkgPath = join(__dirname, '..', '..', 'package.json');
-    const pkg = JSON.parse(readFileSync(pkgPath, 'utf-8'));
-    return pkg.version ?? '0.0.0';
-  } catch {
-    return '0.0.0';
+  const currentDirectory = dirname(fileURLToPath(import.meta.url));
+  const packageCandidates = [
+    join(currentDirectory, '..', 'package.json'),
+    join(currentDirectory, '..', '..', 'package.json'),
+  ] as const;
+  for (const packagePath of packageCandidates) {
+    try {
+      const value: unknown = JSON.parse(readFileSync(packagePath, 'utf-8'));
+      if (
+        typeof value === 'object'
+        && value !== null
+        && 'name' in value
+        && value.name === 'gopeak'
+        && 'version' in value
+        && typeof value.version === 'string'
+      ) {
+        return value.version;
+      }
+    } catch {
+      continue;
+    }
   }
+  return '0.0.0';
 }
 
-/** Fetch latest version from npm registry (no dependencies). */
-export function fetchLatestVersion(): Promise<string | null> {
-  return new Promise((resolve) => {
-    const url = 'https://registry.npmjs.org/gopeak/latest';
-    const timeout = setTimeout(() => resolve(null), 5000);
+export function parseSemver(value: string): ParsedSemver | null {
+  const match = VERSION_PATTERN.exec(value);
+  if (!match) return null;
+  const major = match[1];
+  const minor = match[2];
+  const patch = match[3];
+  if (major === undefined || minor === undefined || patch === undefined) return null;
+  const prereleaseText = match[4];
+  const normalizedCore = `${major}.${minor}.${patch}`;
+  const normalizedPrerelease = prereleaseText ? `-${prereleaseText}` : '';
+  const build = match[5] ? `+${match[5]}` : '';
+  return {
+    major: Number(major),
+    minor: Number(minor),
+    patch: Number(patch),
+    prerelease: prereleaseText ? prereleaseText.split('.') : [],
+    normalized: `${normalizedCore}${normalizedPrerelease}${build}`,
+  };
+}
 
-    httpsGet(url, (res) => {
+export function fetchLatestVersion(options: LatestVersionOptions = {}): Promise<string | null> {
+  const url = new URL(options.url ?? LATEST_RELEASE_URL);
+  const timeoutMs = options.timeoutMs ?? 5_000;
+  const request = url.protocol === 'http:' ? httpGet : httpsGet;
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: string | null): void => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const outgoing = request(url, {
+      headers: {
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'gopeak-update-check',
+      },
+    }, (response) => {
+      if (response.statusCode !== 200) {
+        response.resume();
+        finish(null);
+        return;
+      }
+
       let data = '';
-      res.on('data', (chunk: Buffer) => { data += chunk; });
-      res.on('end', () => {
-        clearTimeout(timeout);
+      let receivedBytes = 0;
+      response.setEncoding('utf8');
+      response.on('data', (chunk: string) => {
+        receivedBytes += Buffer.byteLength(chunk);
+        if (receivedBytes > MAX_RELEASE_RESPONSE_BYTES) {
+          response.destroy();
+          finish(null);
+          return;
+        }
+        data += chunk;
+      });
+      response.on('end', () => {
         try {
-          const json = JSON.parse(data);
-          resolve(json.version ?? null);
+          const value: unknown = JSON.parse(data);
+          if (typeof value !== 'object' || value === null || !('tag_name' in value) || typeof value.tag_name !== 'string') {
+            finish(null);
+            return;
+          }
+          finish(parseSemver(value.tag_name)?.normalized ?? null);
         } catch {
-          resolve(null);
+          finish(null);
         }
       });
-      res.on('error', () => { clearTimeout(timeout); resolve(null); });
-    }).on('error', () => { clearTimeout(timeout); resolve(null); });
+      response.on('error', () => finish(null));
+    });
+
+    outgoing.setTimeout(timeoutMs, () => {
+      outgoing.destroy();
+      finish(null);
+    });
+    outgoing.on('error', () => finish(null));
   });
 }
 
-/** Compare two semver strings. Returns 1 if a > b, -1 if a < b, 0 if equal. */
 export function compareSemver(a: string, b: string): number {
-  const pa = a.replace(/^v/, '').split('.').map(Number);
-  const pb = b.replace(/^v/, '').split('.').map(Number);
-  for (let i = 0; i < 3; i++) {
-    const na = pa[i] ?? 0;
-    const nb = pb[i] ?? 0;
-    if (na > nb) return 1;
-    if (na < nb) return -1;
+  const left = parseSemver(a);
+  const right = parseSemver(b);
+  if (!left || !right) return 0;
+  for (const [leftPart, rightPart] of [
+    [left.major, right.major],
+    [left.minor, right.minor],
+    [left.patch, right.patch],
+  ] as const) {
+    if (leftPart > rightPart) return 1;
+    if (leftPart < rightPart) return -1;
+  }
+  if (left.prerelease.length === 0 && right.prerelease.length === 0) return 0;
+  if (left.prerelease.length === 0) return 1;
+  if (right.prerelease.length === 0) return -1;
+  const identifierCount = Math.max(left.prerelease.length, right.prerelease.length);
+  for (let index = 0; index < identifierCount; index += 1) {
+    const leftIdentifier = left.prerelease[index];
+    const rightIdentifier = right.prerelease[index];
+    if (leftIdentifier === undefined) return -1;
+    if (rightIdentifier === undefined) return 1;
+    if (leftIdentifier === rightIdentifier) continue;
+    const leftIsNumeric = /^\d+$/.test(leftIdentifier);
+    const rightIsNumeric = /^\d+$/.test(rightIdentifier);
+    if (leftIsNumeric && rightIsNumeric) {
+      return Number(leftIdentifier) > Number(rightIdentifier) ? 1 : -1;
+    }
+    if (leftIsNumeric) return -1;
+    if (rightIsNumeric) return 1;
+    return leftIdentifier > rightIdentifier ? 1 : -1;
   }
   return 0;
 }
 
-/* ------------------------------------------------------------------ */
-/*  Cache                                                              */
-/* ------------------------------------------------------------------ */
-
-/** Check if the last update check was less than `maxAgeSeconds` ago. */
-export function isCacheFresh(maxAgeSeconds = 86400): boolean {
+export function isCacheFresh(maxAgeSeconds = 86_400): boolean {
   try {
     if (!existsSync(LAST_CHECK_FILE)) return false;
-    const ts = parseInt(readFileSync(LAST_CHECK_FILE, 'utf-8').trim(), 10);
-    return (Date.now() / 1000 - ts) < maxAgeSeconds;
+    const timestamp = Number.parseInt(readFileSync(LAST_CHECK_FILE, 'utf-8').trim(), 10);
+    return Date.now() / 1_000 - timestamp < maxAgeSeconds;
   } catch {
     return false;
   }
@@ -103,7 +193,7 @@ export function isCacheFresh(maxAgeSeconds = 86400): boolean {
 
 export function updateCacheTimestamp(): void {
   ensureGopeakDir();
-  writeFileSync(LAST_CHECK_FILE, String(Math.floor(Date.now() / 1000)));
+  writeFileSync(LAST_CHECK_FILE, String(Math.floor(Date.now() / 1_000)));
 }
 
 export function writeNotifyFile(message: string): void {
@@ -112,52 +202,36 @@ export function writeNotifyFile(message: string): void {
 }
 
 export function clearNotifyFile(): void {
-  try { if (existsSync(NOTIFY_FILE)) unlinkSync(NOTIFY_FILE); } catch { /* ignore */ }
+  rmSync(NOTIFY_FILE, { force: true });
 }
 
-/* ------------------------------------------------------------------ */
-/*  Shell detection                                                    */
-/* ------------------------------------------------------------------ */
-
 export function getShellRcFile(): string {
-  const shell = process.env.SHELL ?? '';
-  if (shell.includes('zsh')) return join(homedir(), '.zshrc');
-  return join(homedir(), '.bashrc');
+  const homeDirectory = process.env.HOME ?? process.env.USERPROFILE ?? homedir();
+  return join(homeDirectory, (process.env.SHELL ?? '').includes('zsh') ? '.zshrc' : '.bashrc');
 }
 
 export function getShellName(): string {
-  const shell = process.env.SHELL ?? '';
-  if (shell.includes('zsh')) return 'zsh';
-  return 'bash';
+  return (process.env.SHELL ?? '').includes('zsh') ? 'zsh' : 'bash';
 }
 
 export function supportsShellHooks(platform = process.platform, shell = process.env.SHELL ?? ''): boolean {
-  if (platform === 'win32') return false;
-  return shell.includes('bash') || shell.includes('zsh');
+  return platform !== 'win32' && (shell.includes('bash') || shell.includes('zsh'));
 }
 
-/* ------------------------------------------------------------------ */
-/*  Command helpers                                                    */
-/* ------------------------------------------------------------------ */
-
-export async function commandExists(cmd: string): Promise<boolean> {
-  try {
-    await execAsync(`command -v ${cmd}`);
-    return true;
-  } catch {
-    return false;
-  }
+export async function commandExists(command: string): Promise<boolean> {
+  return (await runCommand('which', [command])).code === 0;
 }
 
-export async function runCommand(cmd: string): Promise<{ stdout: string; stderr: string; code: number }> {
-  try {
-    const { stdout, stderr } = await execAsync(cmd);
-    return { stdout: stdout.trim(), stderr: stderr.trim(), code: 0 };
-  } catch (err: any) {
-    return {
-      stdout: (err.stdout ?? '').trim(),
-      stderr: (err.stderr ?? '').trim(),
-      code: err.code ?? 1,
-    };
-  }
+export function runCommand(command: string, args: readonly string[] = []): Promise<CommandResult> {
+  return new Promise((resolve) => {
+    const child = spawn(command, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk: string) => { stdout += chunk; });
+    child.stderr.on('data', (chunk: string) => { stderr += chunk; });
+    child.on('error', (error) => resolve({ stdout: '', stderr: error.message, code: 1 }));
+    child.on('close', (code) => resolve({ stdout: stdout.trim(), stderr: stderr.trim(), code: code ?? 1 }));
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
 /**
  * Godot MCP Server
  *
@@ -6618,6 +6618,9 @@ class GodotServer {
 
       const transport = new StdioServerTransport();
       await this.server.connect(transport);
+      process.stdin.once('end', () => {
+        void this.handleShutdown('stdin:end', 0);
+      });
       console.error('Godot MCP server running on stdio');
 
       // Start the Godot Editor Bridge (WebSocket server for editor plugin).
@@ -6628,7 +6631,15 @@ class GodotServer {
         const bridgeStatus = this.godotBridge.getStatus();
         console.error(`[SERVER] Godot Editor Bridge started on ${bridgeStatus.host}:${bridgeStatus.port}`);
       } catch (bridgeError) {
-        const bridgeMessage = bridgeError instanceof Error ? bridgeError.message : String(bridgeError);
+        const bridgeCode = bridgeError instanceof Error
+          && 'code' in bridgeError
+          && typeof bridgeError.code === 'string'
+          ? bridgeError.code
+          : null;
+        const errorMessage = bridgeError instanceof Error ? bridgeError.message : String(bridgeError);
+        const bridgeMessage = bridgeCode && !errorMessage.includes(bridgeCode)
+          ? `${bridgeCode}: ${errorMessage}`
+          : errorMessage;
         this.bridgeStartupError = bridgeMessage;
         console.error(`[SERVER] Warning: Godot Editor Bridge failed to start: ${bridgeMessage}`);
         console.error('[SERVER] Continuing without bridge-backed editor tools.');
@@ -7590,22 +7601,7 @@ uniform float dissolve_amount : hint_range(0.0, 1.0) = 0.0;
   }
 }
 
-// Create and run the server, but only when index.js is the entry point.
-// Importing the module (e.g. for unit tests of scanDirectoryForGodotBinaries)
-// must NOT start the MCP server.
-const isMainModule = () => {
-  try {
-    return process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1]);
-  } catch {
-    return false;
-  }
-};
-
-if (isMainModule()) {
+export async function runGodotServer(): Promise<void> {
   const server = new GodotServer();
-  server.run().catch((error: unknown) => {
-    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
-    console.error('Failed to run server:', errorMessage);
-    process.exit(1);
-  });
+  await server.run();
 }

--- a/src/server-entry.ts
+++ b/src/server-entry.ts
@@ -1,0 +1,9 @@
+#!/usr/bin/env bun
+
+import { runGodotServer } from './index.js';
+
+await runGodotServer().catch((error: unknown) => {
+  const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+  console.error('Failed to run server:', errorMessage);
+  process.exit(1);
+});

--- a/test-bun-installer.mjs
+++ b/test-bun-installer.mjs
@@ -1,0 +1,299 @@
+#!/usr/bin/env bun
+
+import assert from 'node:assert/strict';
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { createHash } from 'node:crypto';
+import { dirname, join, resolve } from 'node:path';
+import { tmpdir } from 'node:os';
+import { spawn } from 'node:child_process';
+import { createServer } from 'node:net';
+
+const root = new URL('.', import.meta.url).pathname;
+
+async function runInstaller({ version, validChecksum, installed = false, installedVersion = '2.3.8', failNextInstall = false, legacyArgs = [] }) {
+  const home = await mkdtemp(join(tmpdir(), 'gopeak-installer-home-'));
+  const bin = join(home, 'bin');
+  const log = join(home, 'bun.log');
+  const curlLog = join(home, 'curl.log');
+  await mkdir(bin);
+  const archive = Buffer.from('verified release archive');
+  const checksum = createHash('sha256').update(archive).digest('hex');
+
+  const installedMarker = join(home, 'gopeak-installed');
+  const failMarker = join(home, 'fail-next-install');
+  if (installed) await writeFile(installedMarker, 'installed');
+  if (failNextInstall) await writeFile(failMarker, 'fail once');
+  await writeFile(join(bin, 'bun'), `#!/bin/sh
+printf '%s\\n' "HOME=$HOME" "ARGS=$*" >> "$BUN_TEST_LOG"
+if [ "$1 $2" = "pm ls" ] && [ -f "$BUN_INSTALLED_MARKER" ]; then
+  printf '%s\\n' '└── gopeak@/tmp/previous-release.tgz'
+  exit 0
+fi
+if [ "$1 $2 $3" = "remove -g gopeak" ]; then
+  rm -f "$BUN_INSTALLED_MARKER"
+  exit 0
+fi
+if [ "$1 $2" = "add -g" ]; then
+  if [ -f "$BUN_FAIL_MARKER" ]; then
+    rm -f "$BUN_FAIL_MARKER"
+    printf '%s\n' 'simulated replacement failure' >&2
+    exit 42
+  fi
+  if [ -f "$BUN_INSTALLED_MARKER" ]; then
+    printf '%s\\n' 'dependency loop from previous tarball install' >&2
+    exit 42
+  fi
+  : > "$BUN_INSTALLED_MARKER"
+fi
+`);
+  await chmod(join(bin, 'bun'), 0o755);
+  await writeFile(join(bin, 'gopeak'), `#!/bin/sh
+printf '%s\n' 'gopeak v${installedVersion}'
+`);
+  await chmod(join(bin, 'gopeak'), 0o755);
+  await writeFile(join(bin, 'curl'), `#!/bin/sh
+printf '%s\n' "$*" >> "$CURL_TEST_LOG"
+url=""
+output=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) output="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+case "$url" in
+  */releases/latest) payload='{"tag_name":"v2.4.0"}' ;;
+  *.tgz.sha256) payload='${validChecksum ? checksum : '0'.repeat(64)}  gopeak-${version ?? '2.4.0'}.tgz' ;;
+  *.tgz) printf 'verified release archive' > "$output"; exit 0 ;;
+  *) exit 22 ;;
+esac
+if [ -n "$output" ]; then printf '%s' "$payload" > "$output"; else printf '%s' "$payload"; fi
+`);
+  await chmod(join(bin, 'curl'), 0o755);
+
+  const args = [join(root, 'install.sh')];
+  if (version) args.push('--version', version);
+  args.push(...legacyArgs);
+  const result = await new Promise((resolve) => {
+    const child = spawn('/bin/bash', args, {
+      env: {
+        HOME: home,
+        PATH: `${bin}:/usr/bin:/bin`,
+        BUN_TEST_LOG: log,
+        BUN_INSTALLED_MARKER: installedMarker,
+        BUN_FAIL_MARKER: failMarker,
+        CURL_TEST_LOG: curlLog,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (code) => resolve({ code, stdout, stderr }));
+  });
+  let bunLog = '';
+  try { bunLog = await readFile(log, 'utf8'); } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  let curlLogText = '';
+  try { curlLogText = await readFile(curlLog, 'utf8'); } catch (error) {
+    if (error?.code !== 'ENOENT') throw error;
+  }
+  const installationPreserved = await readFile(installedMarker, 'utf8').then(() => true, () => false);
+  await rm(home, { recursive: true, force: true });
+  return { ...result, bunLog, curlLog: curlLogText, home, installationPreserved };
+}
+
+// Given no explicit version and an isolated HOME
+// When the installer runs
+// Then it resolves latest and installs the verified local tarball with Bun.
+const fresh = await runInstaller({ validChecksum: true });
+assert.equal(fresh.code, 0, fresh.stderr);
+assert.match(fresh.stdout, /GoPeak 2\.4\.0/);
+assert.match(fresh.bunLog, /ARGS=add -g .*gopeak-2\.4\.0\.tgz/);
+assert.match(fresh.bunLog, new RegExp(`HOME=${fresh.home}`));
+assert.match(fresh.curlLog, /--proto =https/);
+assert.match(fresh.curlLog, /--proto-redir =https/);
+assert.match(fresh.curlLog, /--max-filesize/);
+
+// Given an explicit release version
+// When the installer runs
+// Then that exact release asset is installed.
+const explicit = await runInstaller({ version: '2.3.9', validChecksum: true });
+assert.equal(explicit.code, 0, explicit.stderr);
+assert.match(explicit.bunLog, /gopeak-2\.3\.9\.tgz/);
+
+// Given GoPeak was already installed from an earlier temporary tarball
+// When the installer upgrades it from a newly downloaded tarball
+// Then the stale global dependency is removed before Bun installs the replacement.
+const upgraded = await runInstaller({ version: '2.3.9', validChecksum: true, installed: true });
+assert.equal(upgraded.code, 0, upgraded.stderr);
+assert.match(upgraded.bunLog, /ARGS=remove -g gopeak[\s\S]*ARGS=add -g/);
+
+// Given the requested release is already installed
+// When the shell installer checks the global package before downloading
+// Then it performs no download, removal, or installation.
+const unchanged = await runInstaller({ version: '2.3.9', validChecksum: true, installed: true, installedVersion: '2.3.9' });
+assert.equal(unchanged.code, 0, unchanged.stderr);
+assert.equal(unchanged.curlLog, '');
+assert.doesNotMatch(unchanged.bunLog, /ARGS=(?:remove|add)/);
+assert.match(unchanged.stdout, /already installed/i);
+
+// Given a verified existing release and a replacement that Bun cannot install
+// When the upgrade fails after removal
+// Then the previous verified release is reinstalled before the installer exits.
+const rolledBack = await runInstaller({ version: '2.4.0', validChecksum: true, installed: true, failNextInstall: true });
+assert.notEqual(rolledBack.code, 0);
+assert.equal(rolledBack.installationPreserved, true, rolledBack.stderr);
+assert.match(rolledBack.bunLog, /ARGS=remove -g gopeak[\s\S]*ARGS=add -g .*2\.4\.0[\s\S]*ARGS=add -g .*2\.3\.8/);
+assert.match(`${rolledBack.stdout}\n${rolledBack.stderr}`, /restored/i);
+
+// Given callers still using the 2.3 installer flags
+// When the Bun installer receives those legacy options
+// Then it accepts them with migration warnings and prints the equivalent Bun-era config.
+const legacy = await runInstaller({
+  version: '2.3.9',
+  validChecksum: true,
+  legacyArgs: ['--dir', '/tmp/old-checkout', '--godot', '/Applications/Godot.app/Contents/MacOS/Godot', '--configure', 'claude'],
+});
+assert.equal(legacy.code, 0, legacy.stderr);
+assert.match(legacy.stderr, /deprecated.*--dir/is);
+assert.match(legacy.stderr, /deprecated.*--godot/is);
+assert.match(legacy.stderr, /deprecated.*--configure/is);
+assert.match(legacy.stdout, /"command": "gopeak"/);
+assert.match(legacy.stdout, /"GODOT_PATH": "\/Applications\/Godot\.app\/Contents\/MacOS\/Godot"/);
+
+// Given a release archive whose checksum is wrong
+// When verification runs
+// Then installation stops before Bun can replace the existing package.
+const rejected = await runInstaller({ version: '2.3.9', validChecksum: false });
+assert.notEqual(rejected.code, 0);
+assert.doesNotMatch(rejected.bunLog, /ARGS=(?:remove|add)/);
+assert.match(`${rejected.stdout}\n${rejected.stderr}`, /checksum/i);
+
+async function reservePort() {
+  return await new Promise((resolvePort, rejectPort) => {
+    const server = createServer();
+    server.unref();
+    server.on('error', rejectPort);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => rejectPort(new Error('could not reserve MCP bridge port')));
+        return;
+      }
+      server.close((error) => error ? rejectPort(error) : resolvePort(address.port));
+    });
+  });
+}
+
+async function runProcess(command, args, env) {
+  return await new Promise((resolveProcess) => {
+    const child = spawn(command, args, { env, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => { stdout += chunk; });
+    child.stderr.on('data', (chunk) => { stderr += chunk; });
+    child.on('close', (code) => resolveProcess({ code, stdout, stderr }));
+  });
+}
+
+async function initializeInstalledBin(command, env) {
+  const child = spawn(command, [], { env, stdio: ['pipe', 'pipe', 'pipe'] });
+  const closed = new Promise((resolveClose) => child.once('close', resolveClose));
+  let stdout = '';
+  let stderr = '';
+  child.stdout.on('data', (chunk) => { stdout += chunk; });
+  child.stderr.on('data', (chunk) => { stderr += chunk; });
+  const response = new Promise((resolveResponse, rejectResponse) => {
+    const timeout = setTimeout(() => rejectResponse(new Error(`MCP initialize timed out: ${stderr}`)), 10_000);
+    child.stdout.on('data', () => {
+      for (const line of stdout.split('\n')) {
+        if (!line.trim()) continue;
+        try {
+          const message = JSON.parse(line);
+          if (message.id === 1 && message.result?.serverInfo?.name === 'gopeak') {
+            clearTimeout(timeout);
+            resolveResponse(message);
+            return;
+          }
+        } catch (error) {
+          if (!(error instanceof SyntaxError)) throw error;
+        }
+      }
+    });
+    child.on('close', (code) => {
+      clearTimeout(timeout);
+      rejectResponse(new Error(`MCP bin exited before initialize response (code ${code}): ${stderr}`));
+    });
+  });
+  child.stdin.write(`${JSON.stringify({
+    jsonrpc: '2.0',
+    id: 1,
+    method: 'initialize',
+    params: {
+      protocolVersion: '2024-11-05',
+      capabilities: {},
+      clientInfo: { name: 'distribution-test', version: '1.0.0' },
+    },
+  })}\n`);
+  let exitTimeout;
+  try {
+    await response;
+    child.stdin.end();
+    await Promise.race([
+      closed,
+      new Promise((_, rejectExit) => {
+        exitTimeout = setTimeout(() => rejectExit(new Error(`MCP bin did not exit after stdin closed: ${stderr}`)), 5_000);
+      }),
+    ]);
+  } finally {
+    clearTimeout(exitTimeout);
+    if (child.exitCode === null) {
+      child.kill('SIGTERM');
+      await closed;
+    }
+  }
+  const initializeResponses = stdout
+    .split('\n')
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line))
+    .filter((message) => message.id === 1);
+  assert.equal(initializeResponses.length, 1, `${command} must emit exactly one initialize response`);
+  assert.equal((stderr.match(/Godot MCP server running on stdio/g) ?? []).length, 1, `${command} must start exactly one MCP server`);
+}
+
+// Given the release tarball and a clean Bun global prefix
+// When an end user installs it with the real Bun executable
+// Then both installed bins report the release version and complete an MCP initialize handshake.
+const realHome = await mkdtemp(join(tmpdir(), 'gopeak-real-global-'));
+try {
+  const bunInstall = join(realHome, '.bun');
+  const realEnv = {
+    ...process.env,
+    HOME: realHome,
+    BUN_INSTALL: bunInstall,
+    PATH: `${dirname(process.execPath)}:${process.env.PATH ?? '/usr/bin:/bin'}`,
+    GODOT_PATH: process.execPath,
+    GOPEAK_BRIDGE_HOST: '127.0.0.1',
+  };
+  const archivePath = resolve(root, 'dist', 'gopeak-2.3.9.tgz');
+  const installation = await runProcess(process.execPath, ['add', '-g', archivePath], realEnv);
+  assert.equal(installation.code, 0, installation.stderr);
+  for (const binaryName of ['gopeak', 'godot-mcp']) {
+    const binary = join(bunInstall, 'bin', binaryName);
+    const versionResult = await runProcess(binary, ['version'], realEnv);
+    assert.equal(versionResult.code, 0, versionResult.stderr);
+    assert.match(versionResult.stdout, /gopeak v2\.3\.9/);
+    await initializeInstalledBin(binary, {
+      ...realEnv,
+      GOPEAK_BRIDGE_PORT: String(await reservePort()),
+    });
+  }
+} finally {
+  await rm(realHome, { recursive: true, force: true });
+}
+
+console.log('Bun installer tests passed');

--- a/test-docs-package-policy.mjs
+++ b/test-docs-package-policy.mjs
@@ -7,6 +7,32 @@ const pkg = JSON.parse(read('package.json'));
 const server = JSON.parse(read('server.json'));
 const readme = read('README.md');
 const migration = read('docs/migration-policy.md');
+const releaseProcess = read('docs/release-process.md');
+const changelog = read('CHANGELOG.md');
+const escapedVersion = pkg.version.replaceAll('.', '\\.');
+const currentRelease = changelog.match(new RegExp(`## \\[${escapedVersion}\\][\\s\\S]*?(?=\\n## \\[|$)`))?.[0] ?? '';
+const currentDocs = [
+  'README.md',
+  'README-ko.md',
+  'README-ja.md',
+  'README-de.md',
+  'README-pt_BR.md',
+  'README-zh.md',
+  'index.html',
+  'CONTRIBUTING.md',
+  'ROADMAP.md',
+  'docs/architecture.md',
+  'docs/platform-roadmap.md',
+  'docs/release-process.md',
+].map((path) => [path, read(path)]);
+
+for (const [scriptName, command] of Object.entries(pkg.scripts ?? {})) {
+  assert.doesNotMatch(
+    command,
+    /(?:^|\s)(?:node|npm|npx|bunx|bun\s+x)(?:\s|$)/,
+    `${scriptName} should run through Bun without a hidden Node or registry-backed executable`,
+  );
+}
 
 for (const [source, description] of [
   ['package.json', pkg.description],
@@ -21,6 +47,30 @@ assert.match(readme, /setup-gated/i, 'README should label optional capabilities 
 assert.match(readme, /TileMapLayer/, 'README should document Godot 4.3+ TileMapLayer migration risk');
 assert.doesNotMatch(readme, /110-tool context bombs/i, 'README should avoid raw tool-count marketing language');
 assert.doesNotMatch(readme, /110\+ tools available/i, 'README should avoid raw tool-count value claim');
+assert.match(
+  readme,
+  new RegExp(`releases/download/v?${escapedVersion}/gopeak-${escapedVersion}\\.tgz`),
+  'README should install the versioned GitHub Release asset',
+);
+assert.match(readme, /bun add -g "\$PWD\/gopeak-/, 'README should install GoPeak with Bun using an absolute tarball path');
+assert.match(
+  readme,
+  /git clone https:\/\/github\.com\/HaD0Yun\/Doyunha-Gopeak\.git\s+cd Doyunha-Gopeak/,
+  'README clone examples should enter the canonical checkout directory',
+);
+
+for (const [path, contents] of currentDocs) {
+  assert.doesNotMatch(contents, /\bnpx\b/i, `${path} should not contain current npx instructions`);
+  assert.doesNotMatch(contents, /\bnpm\s+(?:i|install|update|publish|pack|run)\b/i, `${path} should not contain current npm commands`);
+  assert.doesNotMatch(contents, /npmjs\.com/i, `${path} should not link to the npm registry`);
+  assert.doesNotMatch(contents, /bun publish/i, `${path} should never claim releases use bun publish`);
+  assert.doesNotMatch(contents, /Node\.js\s+18/i, `${path} should not require Node.js for the Bun distribution`);
+  assert.doesNotMatch(contents, /cd Gopeak-godot-mcp/, `${path} should not enter the retired repository directory`);
+}
+
+assert.match(currentRelease, /GitHub Release/i, 'current changelog entry should describe GitHub Release distribution');
+assert.match(currentRelease, /Bun/i, 'current changelog entry should describe Bun installation');
+assert.doesNotMatch(currentRelease, /\b(?:npm|npx)\b.*\b(?:install|update|publish|release)\b/i, 'current changelog entry should not claim a registry install or release flow');
 
 for (const required of ['Old surface', 'New surface', 'Change type', 'Profile impact', 'Alias window', 'Verification']) {
   assert.match(migration, new RegExp(required), `migration policy should define ${required}`);
@@ -29,5 +79,22 @@ for (const required of ['Old surface', 'New surface', 'Change type', 'Profile im
 for (const gate of ['optional-runtime', 'optional-lsp', 'optional-dap', 'optional-network', 'workflow layer']) {
   assert.match(migration, new RegExp(gate.replace(' ', '\\s+'), 'i'), `migration policy should mention ${gate}`);
 }
+
+for (const legacyFlag of ['--dir', '--godot', '--configure']) {
+  assert.match(migration, new RegExp(legacyFlag), `migration policy should map legacy installer flag ${legacyFlag}`);
+}
+
+assert.match(migration, /2\.3\.x/, 'legacy installer flags should have an explicit 2.3.x compatibility window');
+assert.match(
+  migration,
+  /does not (?:publish to|contact) the npm registry/i,
+  'migration policy should state that release installation is registry-free',
+);
+assert.match(
+  releaseProcess,
+  /gh attestation verify .*gopeak-X\.Y\.Z\.tgz.*--repo HaD0Yun\/Doyunha-Gopeak/i,
+  'release docs should show GitHub artifact attestation verification',
+);
+assert.match(releaseProcess, /SHA-256[\s\S]*attestation/i, 'release docs should distinguish checksum and provenance verification');
 
 console.log('docs/package migration policy checks passed');

--- a/test-github-update.mjs
+++ b/test-github-update.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env bun
+
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { Readable } from 'node:stream';
+import { pipeline } from 'node:stream/promises';
+import { fetchLatestVersion, compareSemver } from './src/cli/utils.ts';
+import * as updater from './src/cli/update.ts';
+
+const { installRelease } = updater;
+
+async function withServer(handler, run) {
+  const server = createServer(handler);
+  await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  try {
+    await run(`http://127.0.0.1:${address.port}/latest`);
+  } finally {
+    await new Promise((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+  }
+}
+
+// Given a newer, valid GitHub release response
+// When the latest version is fetched
+// Then its tag is parsed and compares newer than the installed version.
+await withServer((_request, response) => {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ tag_name: 'v2.4.0' }));
+}, async (url) => {
+  const latest = await fetchLatestVersion({ url, timeoutMs: 500 });
+  assert.equal(latest, '2.4.0');
+  assert.equal(compareSemver(latest ?? '', '2.3.9'), 1);
+});
+
+// Given a release equal to the installed version
+// When the response is fetched and versions are compared
+// Then no update is reported.
+await withServer((_request, response) => {
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ tag_name: 'v2.3.9' }));
+}, async (url) => {
+  const latest = await fetchLatestVersion({ url, timeoutMs: 500 });
+  assert.equal(latest, '2.3.9');
+  assert.equal(compareSemver(latest ?? '', '2.3.9'), 0);
+});
+
+// Given valid stable, prerelease, and build-metadata versions
+// When SemVer precedence is compared
+// Then numeric identifiers and prerelease precedence follow SemVer 2.0.0.
+assert.equal(compareSemver('2.4.0-beta.2', '2.4.0-beta.11'), -1);
+assert.equal(compareSemver('2.4.0-beta.11', '2.4.0'), -1);
+assert.equal(compareSemver('2.4.0+build.7', '2.4.0+build.9'), 0);
+
+// Given malformed GitHub release tags
+// When the release boundary parses them
+// Then ambiguous prerelease identifiers and leading-zero core versions are rejected.
+for (const malformedTag of ['v2.3.9...', 'v2.3.9-..', 'v02.3.9', 'v2.03.9', 'v2.3.09', 'v2.3.9-01']) {
+  await withServer((_request, response) => {
+    response.writeHead(200, { 'content-type': 'application/json' });
+    response.end(JSON.stringify({ tag_name: malformedTag }));
+  }, async (url) => {
+    assert.equal(await fetchLatestVersion({ url, timeoutMs: 500 }), null, malformedTag);
+  });
+}
+
+// Given malformed JSON from GitHub
+// When the latest version is fetched
+// Then the boundary rejects it without inventing a version.
+await withServer((_request, response) => response.end('{broken'), async (url) => {
+  assert.equal(await fetchLatestVersion({ url, timeoutMs: 500 }), null);
+});
+
+// Given a missing release endpoint
+// When GitHub answers 404
+// Then the update check returns no version.
+await withServer((_request, response) => {
+  response.writeHead(404);
+  response.end('missing');
+}, async (url) => {
+  assert.equal(await fetchLatestVersion({ url, timeoutMs: 500 }), null);
+});
+
+// Given an endpoint that does not respond before the deadline
+// When the update check times out
+// Then it returns no version promptly.
+await withServer(() => {}, async (url) => {
+  const startedAt = Date.now();
+  assert.equal(await fetchLatestVersion({ url, timeoutMs: 40 }), null);
+  assert(Date.now() - startedAt < 500);
+});
+
+// Given an untrusted release version containing path traversal
+// When installation is requested
+// Then it is rejected before any download or subprocess can run.
+await assert.rejects(() => installRelease('../../malicious'), /malformed/);
+
+// Given an updater transport boundary
+// When a release URL downgrades to plaintext HTTP
+// Then it is rejected before a request is sent.
+assert.equal(typeof updater.assertSecureReleaseUrl, 'function');
+assert.throws(() => updater.assertSecureReleaseUrl('http://example.test/gopeak.tgz'), /HTTPS/i);
+
+// Given a release body larger than its configured safety limit
+// When it streams through the downloader
+// Then the transfer is aborted instead of consuming unbounded disk space.
+assert.equal(typeof updater.createDownloadLimiter, 'function');
+await assert.rejects(
+  () => pipeline(Readable.from([Buffer.alloc(5), Buffer.alloc(5)]), updater.createDownloadLimiter(8)),
+  /size limit/i,
+);
+
+// Given a verified previous release and a verified replacement
+// When Bun fails to install the replacement after removing the old package
+// Then the updater restores the previous release before surfacing the failure.
+assert.equal(typeof updater.replaceGlobalPackage, 'function');
+const commands = [];
+const fakeRunner = async (command, args) => {
+  commands.push([command, ...args].join(' '));
+  if (args.at(-1) === '/verified/new.tgz') return { code: 42, stdout: '', stderr: 'install failed' };
+  return { code: 0, stdout: '', stderr: '' };
+};
+await assert.rejects(
+  () => updater.replaceGlobalPackage({
+    nextArchive: '/verified/new.tgz',
+    rollbackArchive: '/verified/old.tgz',
+  }, fakeRunner),
+  /restored/i,
+);
+assert.deepEqual(commands, [
+  'bun remove -g gopeak',
+  'bun add -g /verified/new.tgz',
+  'bun add -g /verified/old.tgz',
+]);
+
+// Given the requested release is already globally installed
+// When the TypeScript updater evaluates the installation
+// Then it returns before any download, removal, or installation command.
+const sameVersionCommands = [];
+const sameVersionRunner = async (command, args) => {
+  sameVersionCommands.push([command, ...args].join(' '));
+  if (args.join(' ') === 'pm ls -g') return { code: 0, stdout: '└── gopeak@999.0.0', stderr: '' };
+  if (command === 'gopeak') return { code: 0, stdout: 'gopeak v999.0.0', stderr: '' };
+  return { code: 99, stdout: '', stderr: 'unexpected mutation' };
+};
+await updater.installRelease('999.0.0', sameVersionRunner);
+assert.deepEqual(sameVersionCommands, ['bun pm ls -g', 'gopeak version']);
+
+console.log('GitHub update tests passed');

--- a/test-godot-detection.mjs
+++ b/test-godot-detection.mjs
@@ -16,7 +16,7 @@ import { mkdtempSync, mkdirSync, writeFileSync, rmSync, statSync, utimesSync } f
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
-const { scanDirectoryForGodotBinaries } = await import('./build/index.js');
+const { scanDirectoryForGodotBinaries } = await import('./src/index.ts');
 
 function testIgnoresEmptyAndMissingDirectories() {
   assert.deepEqual(scanDirectoryForGodotBinaries(''), [], 'empty directory returns no candidates');

--- a/test-metadata-consistency.mjs
+++ b/test-metadata-consistency.mjs
@@ -9,10 +9,30 @@ const pkg = JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url
 const serverManifest = JSON.parse(fs.readFileSync(new URL('./server.json', import.meta.url), 'utf8'));
 
 assert.equal(serverManifest.version, pkg.version, 'server.json version should match package.json');
-assert.equal(serverManifest.packages?.[0]?.identifier, pkg.name, 'server.json package identifier should match package name');
-assert.equal(serverManifest.packages?.[0]?.version, pkg.version, 'server.json package version should match package version');
+assert.equal(serverManifest.packages, undefined, 'server.json should not advertise a registry package for a GitHub Release tarball');
+assert.equal(serverManifest.websiteUrl, pkg.homepage, 'server.json website should match the package homepage');
+assert.equal(serverManifest.repository?.url, 'https://github.com/HaD0Yun/Doyunha-Gopeak', 'server.json should link to the canonical GitHub repository');
+assert.equal(serverManifest.websiteUrl, 'https://github.com/HaD0Yun/Doyunha-Gopeak#readme', 'server.json should link to the canonical project page');
+assert.equal(pkg.repository?.url, 'git+https://github.com/HaD0Yun/Doyunha-Gopeak.git', 'package.json should link to the canonical GitHub repository');
+assert.equal(serverManifest.repository?.source, 'github', 'server.json should identify GitHub as its repository source');
+
+// Given current runtime and installer surfaces
+// When repository links or GitHub API coordinates are embedded
+// Then none may point users or automation to the retired repository name.
+for (const path of [
+  'src/cli/check.ts',
+  'src/cli/notify.ts',
+  'src/cli/setup.ts',
+  'src/cli/star.ts',
+  'install-addon.sh',
+  'install-addon.ps1',
+]) {
+  const contents = fs.readFileSync(new URL(`./${path}`, import.meta.url), 'utf8');
+  assert.doesNotMatch(contents, /HaD0Yun\/Gopeak-godot-mcp/i, `${path} should use the canonical repository name`);
+}
 assert.match(pkg.description, /GoPeak/i, 'package description should use GoPeak branding');
 assert.match(serverManifest.description, /GoPeak/i, 'server manifest description should use GoPeak branding');
+assert.ok(serverManifest.description.length <= 100, 'server.json description must satisfy the MCP schema 100-character limit');
 
 const versionOutput = execFileSync(process.execPath, ['./build/cli.js', 'version'], {
   cwd: process.cwd(),
@@ -20,7 +40,7 @@ const versionOutput = execFileSync(process.execPath, ['./build/cli.js', 'version
 }).trim();
 assert.equal(versionOutput, `gopeak v${pkg.version}`, 'CLI version output should stay in sync with package.json');
 
-const child = spawn(process.execPath, ['./build/index.js'], {
+const child = spawn(process.execPath, ['./build/cli.js'], {
   cwd: process.cwd(),
   env: {
     ...process.env,
@@ -42,7 +62,7 @@ child.stderr.on('data', (chunk) => {
 
 try {
   await delay(500);
-  assert.equal(child.exitCode, null, `build/index.js exited during startup: ${stderr}`);
+  assert.equal(child.exitCode, null, `build/cli.js exited during startup: ${stderr}`);
 
   child.stdin.write(`${JSON.stringify({
     jsonrpc: '2.0',

--- a/test-offline-release-install.mjs
+++ b/test-offline-release-install.mjs
@@ -1,0 +1,54 @@
+#!/usr/bin/env bun
+
+import assert from 'node:assert/strict';
+import { lstat, mkdtemp, readlink, rm } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const root = import.meta.dirname;
+const pkg = await Bun.file(path.join(root, 'package.json')).json();
+const archivePath = path.join(root, 'dist', `gopeak-${pkg.version}.tgz`);
+const installRoot = await mkdtemp(path.join(os.tmpdir(), 'gopeak-offline-install-'));
+
+try {
+  // Given: an isolated Bun home whose registry and proxies cannot reach a package server.
+  const env = {
+    ...process.env,
+    HOME: installRoot,
+    BUN_INSTALL: installRoot,
+    BUN_INSTALL_CACHE_DIR: path.join(installRoot, 'cache'),
+    BUN_CONFIG_REGISTRY: 'http://127.0.0.1:9',
+    HTTP_PROXY: 'http://127.0.0.1:9',
+    HTTPS_PROXY: 'http://127.0.0.1:9',
+    NO_PROXY: '',
+  };
+
+  // When: the versioned GitHub Release artifact is installed globally.
+  const install = Bun.spawnSync([process.execPath, 'add', '--global', archivePath], {
+    cwd: installRoot,
+    env,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  // Then: installation needs no registry and exposes both supported commands.
+  assert.equal(install.exitCode, 0, install.stderr.toString());
+  for (const [binName, targetName] of [['gopeak', 'cli.js'], ['godot-mcp', 'godot-mcp.js']]) {
+    const binPath = path.join(installRoot, 'bin', binName);
+    assert.equal((await lstat(binPath)).isSymbolicLink(), true, `${binName} should be linked globally`);
+    assert.ok((await readlink(binPath)).endsWith(`/node_modules/gopeak/build/${targetName}`));
+
+    const version = Bun.spawnSync([binPath, 'version'], {
+      cwd: installRoot,
+      env,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    assert.equal(version.exitCode, 0, version.stderr.toString());
+    assert.equal(version.stdout.toString().trim(), `gopeak v${pkg.version}`);
+  }
+} finally {
+  await rm(installRoot, { recursive: true, force: true });
+}
+
+console.log(`Offline Bun release install verified with Bun ${Bun.version}`);

--- a/test-packaging-consistency.mjs
+++ b/test-packaging-consistency.mjs
@@ -1,36 +1,126 @@
-#!/usr/bin/env node
+#!/usr/bin/env bun
+
 import assert from 'node:assert/strict';
-import { execFileSync } from 'node:child_process';
-import fs from 'node:fs';
+import { createHash } from 'node:crypto';
+import { chmod, mkdtemp, readFile, readdir, rm, stat } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 
-const pkg = JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
-const npmCmd = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const root = import.meta.dirname;
+const pkg = await Bun.file(path.join(root, 'package.json')).json();
+const archiveName = `gopeak-${pkg.version}.tgz`;
+const archivePath = path.join(root, 'dist', archiveName);
+const checksumPath = `${archivePath}.sha256`;
 
-const packOutput = execFileSync(npmCmd, ['pack', '--dry-run', '--json', '--ignore-scripts'], {
-  cwd: process.cwd(),
-  encoding: 'utf8',
-});
-
-const jsonStart = packOutput.lastIndexOf('\n[');
-const normalizedPackOutput = jsonStart >= 0 ? packOutput.slice(jsonStart + 1) : packOutput.trim();
-const packEntries = JSON.parse(normalizedPackOutput);
-assert.ok(Array.isArray(packEntries) && packEntries.length > 0, 'npm pack --json should return at least one entry');
-
-const packedFiles = new Set((packEntries[0].files || []).map((file) => file.path));
-
-assert.ok(packedFiles.has('build/cli.js'), 'published package should include build/cli.js');
-assert.ok(packedFiles.has('build/index.js'), 'published package should include build/index.js');
-
-const postinstallScript = pkg.scripts?.postinstall;
-assert.equal(typeof postinstallScript, 'string', 'package.json should define a postinstall script');
-
-const nodeScriptMatch = postinstallScript.match(/\bnode\s+([^\s]+)/);
-assert.ok(nodeScriptMatch, `postinstall should execute a concrete node script: ${postinstallScript}`);
-
-const postinstallTarget = nodeScriptMatch[1];
-assert.ok(
-  packedFiles.has(postinstallTarget),
-  `published package must include the postinstall target referenced by package.json: ${postinstallTarget}`,
+assert.equal(await Bun.file(archivePath).exists(), true, `${archiveName} should exist; run bun run release:pack first`);
+assert.equal(await Bun.file(checksumPath).exists(), true, `${archiveName}.sha256 should exist`);
+assert.deepEqual(
+  (await readdir(path.join(root, 'dist'))).sort(),
+  [archiveName, `${archiveName}.sha256`],
+  'release packing should remove stale version artifacts',
 );
 
-console.log('packaging consistency regression checks passed');
+const archiveBytes = new Uint8Array(await Bun.file(archivePath).arrayBuffer());
+const actualChecksum = createHash('sha256').update(archiveBytes).digest('hex');
+const checksumFile = (await readFile(checksumPath, 'utf8')).trim();
+assert.equal(checksumFile, `${actualChecksum}  ${archiveName}`, 'SHA-256 sidecar should match the release archive');
+
+const tarList = Bun.spawnSync(['tar', '-tzf', archivePath], { cwd: root, stdout: 'pipe', stderr: 'pipe' });
+assert.equal(tarList.exitCode, 0, tarList.stderr.toString());
+const archiveEntries = tarList.stdout.toString().trim().split('\n');
+const packedFiles = new Set(archiveEntries);
+assert.equal(
+  packedFiles.size,
+  archiveEntries.length,
+  'release archive should not contain duplicate paths',
+);
+assert.equal(
+  archiveEntries.some((entry) => entry.startsWith('package/node_modules/')),
+  false,
+  'release archive should contain bundles instead of a node_modules tree',
+);
+
+for (const requiredFile of [
+  'package/package.json',
+  'package/build/cli.js',
+  'package/build/godot-mcp.js',
+  'package/build/index.js',
+  'package/build/visualizer.html',
+  'package/build/scripts/godot_operations.gd',
+  'package/build/addon/auto_reload/plugin.cfg',
+  'package/build/addon/godot_mcp_editor/plugin.cfg',
+  'package/build/addon/godot_mcp_runtime/plugin.cfg',
+  'package/README.md',
+  'package/LICENSE',
+]) {
+  assert.ok(packedFiles.has(requiredFile), `release archive should include ${requiredFile}`);
+}
+
+for (const forbiddenFile of [
+  'package/src/cli.ts',
+  'package/build/godot-bridge.js',
+  'package/scripts/postinstall.mjs',
+  'package/scripts/build-release.mjs',
+]) {
+  assert.equal(packedFiles.has(forbiddenFile), false, `release archive should exclude ${forbiddenFile}`);
+}
+
+const extractionRoot = await mkdtemp(path.join(os.tmpdir(), 'gopeak-packaging-'));
+try {
+  const extract = Bun.spawnSync(['tar', '-xzf', archivePath, '-C', extractionRoot], {
+    cwd: root,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  assert.equal(extract.exitCode, 0, extract.stderr.toString());
+
+  const packedRoot = path.join(extractionRoot, 'package');
+  const packedPackage = JSON.parse(await readFile(path.join(packedRoot, 'package.json'), 'utf8'));
+  assert.deepEqual(packedPackage.dependencies ?? {}, {}, 'packed runtime should not fetch dependencies');
+  assert.deepEqual(packedPackage.peerDependencies ?? {}, {}, 'packed runtime should not fetch peer dependencies');
+  assert.deepEqual(packedPackage.optionalDependencies ?? {}, {}, 'packed runtime should not fetch optional dependencies');
+  assert.equal(packedPackage.devDependencies, undefined, 'packed runtime should not include development dependencies');
+  assert.equal(packedPackage.scripts?.prepare, undefined, 'packed package should not require prepare');
+  assert.equal(packedPackage.scripts?.postinstall, undefined, 'packed package should not require postinstall');
+
+  const scriptCommands = Object.values(packedPackage.scripts ?? {}).join('\n');
+  assert.doesNotMatch(scriptCommands, /\b(?:npm|npx)\b/, 'packed scripts should use Bun, not npm or npx commands');
+
+  const cliPath = path.join(packedRoot, 'build', 'cli.js');
+  const cliMode = (await stat(cliPath)).mode & 0o777;
+  assert.equal(cliMode, 0o755, 'packed CLI should be executable without world-writable permissions');
+  assert.equal(
+    (await stat(path.join(packedRoot, 'build', 'godot-mcp.js'))).mode & 0o777,
+    0o755,
+    'packed compatibility bin should be executable without world-writable permissions',
+  );
+  assert.ok(
+    (await readFile(cliPath, 'utf8')).startsWith('#!/usr/bin/env bun\n'),
+    'packed CLI should execute with Bun when linked as a global bin',
+  );
+  for (const bundleName of ['cli.js', 'index.js']) {
+    const bundle = await readFile(path.join(packedRoot, 'build', bundleName), 'utf8');
+    const externalPackageImport = bundle.match(
+      /(?:from\s+|import\()["'](?:@modelcontextprotocol|fs-extra)(?:[\/"'])/,
+    )?.[0] ?? null;
+    assert.equal(
+      externalPackageImport,
+      null,
+      `${bundleName} should not import a package that is absent from the release manifest`,
+    );
+  }
+
+  // Some archive tools on Windows do not restore executable mode; Bun can still run the prebuilt bin.
+  await chmod(cliPath, 0o755);
+  const cli = Bun.spawnSync([process.execPath, cliPath, 'version'], {
+    cwd: packedRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+  assert.equal(cli.exitCode, 0, cli.stderr.toString());
+  assert.equal(cli.stdout.toString().trim(), `gopeak v${pkg.version}`, 'packed bin should report the archive version');
+} finally {
+  await rm(extractionRoot, { recursive: true, force: true });
+}
+
+console.log(`Bun release archive verified: dist/${archiveName}`);

--- a/test-readme-localization-consistency.mjs
+++ b/test-readme-localization-consistency.mjs
@@ -12,6 +12,9 @@ const LOCALES = [
 ];
 
 const rootReadme = fs.readFileSync(new URL(`./${ROOT_README}`, import.meta.url), 'utf8');
+const pkg = JSON.parse(fs.readFileSync(new URL('./package.json', import.meta.url), 'utf8'));
+const escapedVersion = pkg.version.replaceAll('.', '\\.');
+const releaseAssetPattern = new RegExp(`releases/download/v?${escapedVersion}/gopeak-${escapedVersion}\\.tgz`);
 
 for (const locale of LOCALES) {
   assert.match(rootReadme, new RegExp(`\\(${locale.replace('.', '\\.')}`), `${ROOT_README} should link to ${locale}`);
@@ -25,6 +28,9 @@ for (const locale of LOCALES) {
     /Canonical docs:\s*\[README\.md\]\(README\.md\)\./,
     `${locale} should declare README.md as the canonical source`,
   );
+  assert.match(localized, releaseAssetPattern, `${locale} should install the versioned GitHub Release asset`);
+  assert.match(localized, /bun add -g "\$PWD\/gopeak-/, `${locale} should install GoPeak with Bun using an absolute tarball path`);
+  assert.doesNotMatch(localized, /\b(?:npm|npx)\b/i, `${locale} should not direct users to npm or npx`);
 }
 
 console.log('README localization consistency checks passed');

--- a/test-setup-hooks.mjs
+++ b/test-setup-hooks.mjs
@@ -4,8 +4,8 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-const utils = await import('./build/cli/utils.js');
-const { setupShellHooks, MARKER_START, MARKER_END } = await import('./build/cli/setup.js');
+const utils = await import('./src/cli/utils.ts');
+const { setupShellHooks, MARKER_START, MARKER_END } = await import('./src/cli/setup.ts');
 
 assert.equal(utils.supportsShellHooks('win32', ''), false, 'Windows must not install bash/zsh hooks');
 assert.equal(utils.supportsShellHooks('linux', '/bin/bash'), true, 'bash on Unix-like systems should be supported');

--- a/test-version-bump.mjs
+++ b/test-version-bump.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env bun
+
+import assert from 'node:assert/strict';
+import { cp, mkdtemp, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+
+const root = import.meta.dirname;
+const fixtureRoot = await mkdtemp(path.join(os.tmpdir(), 'gopeak-version-bump-'));
+const maintainedFiles = [
+  'README.md',
+  'README-de.md',
+  'README-ja.md',
+  'README-ko.md',
+  'README-pt_BR.md',
+  'README-zh.md',
+  'index.html',
+];
+
+try {
+  // Given: every maintained install surface points at the current release asset.
+  await mkdir(path.join(fixtureRoot, 'scripts'), { recursive: true });
+  await cp(path.join(root, 'scripts', 'bump-version.mjs'), path.join(fixtureRoot, 'scripts', 'bump-version.mjs'));
+  await writeFile(path.join(fixtureRoot, 'package.json'), '{"name":"gopeak","version":"2.3.9"}\n');
+  await writeFile(path.join(fixtureRoot, 'server.json'), '{"name":"io.github.HaD0Yun/gopeak","version":"2.3.9"}\n');
+  for (const fileName of maintainedFiles) {
+    await writeFile(
+      path.join(fixtureRoot, fileName),
+      'https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz\n' +
+        'gopeak-2.3.9.tgz.sha256\nbun add -g "$PWD/gopeak-2.3.9.tgz"\n',
+    );
+  }
+
+  // When: the release version is bumped once.
+  const bump = Bun.spawnSync([process.execPath, 'scripts/bump-version.mjs', '2.4.0'], {
+    cwd: fixtureRoot,
+    stdout: 'pipe',
+    stderr: 'pipe',
+  });
+
+  // Then: metadata and every maintained download/install reference move together.
+  assert.equal(bump.exitCode, 0, bump.stderr.toString());
+  assert.equal(JSON.parse(await readFile(path.join(fixtureRoot, 'package.json'), 'utf8')).version, '2.4.0');
+  assert.equal(JSON.parse(await readFile(path.join(fixtureRoot, 'server.json'), 'utf8')).version, '2.4.0');
+  for (const fileName of maintainedFiles) {
+    const content = await readFile(path.join(fixtureRoot, fileName), 'utf8');
+    assert.doesNotMatch(content, /2\.3\.9/, `${fileName} should not retain the previous release version`);
+    assert.match(content, /releases\/download\/v2\.4\.0\/gopeak-2\.4\.0\.tgz/);
+    assert.match(content, /gopeak-2\.4\.0\.tgz\.sha256/);
+    assert.match(content, /\$PWD\/gopeak-2\.4\.0\.tgz/);
+  }
+} finally {
+  await rm(fixtureRoot, { recursive: true, force: true });
+}
+
+console.log('version bump synchronization checks passed');


### PR DESCRIPTION
## Summary
- remove npm publishing/authentication and npx-based distribution paths
- ship dependency-free Bun runtime archives with SHA-256 verification
- install and update from canonical GitHub Releases with rollback and legacy flag compatibility
- add pinned, least-privilege release automation with provenance attestations
- update all user and contributor documentation

## Verification
- exact Bun 1.3.3 with Node absent from PATH
- build, typecheck, CI, integration, dynamic groups, docs, metadata, setup, distribution
- offline global install of both bins
- exactly one MCP initialize response and 33 tools per bin
- clean stdin EOF exit
- 2.3.8 -> 2.3.9 upgrade, checksum preservation, failed-install rollback, same-version no-op
- five independent final review lanes and runtime debugging audit passed