### PR TITLE
docs: add one-line Bun installation

### DIFF
--- a/README-de.md
+++ b/README-de.md
@@ -15,6 +15,13 @@
 
 ### Starten
 ```bash
+bun add -g https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+gopeak
+```
+
+Dies ist der einfachste Installationsweg. Das Bundle wird ohne Paket-Registry direkt aus dem GitHub Release installiert. Für eine zusätzliche Prüfsummenprüfung verwende:
+
+```bash
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
 if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi

--- a/README-ja.md
+++ b/README-ja.md
@@ -15,6 +15,13 @@
 
 ### 実行
 ```bash
+bun add -g https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+gopeak
+```
+
+これは最も簡単なインストール方法です。パッケージレジストリを使わず、GitHub Release のバンドルを直接インストールします。チェックサムも検証する場合は、次の方法を使用してください。
+
+```bash
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
 if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi

--- a/README-ko.md
+++ b/README-ko.md
@@ -15,6 +15,13 @@
 
 ### 실행
 ```bash
+bun add -g https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+gopeak
+```
+
+가장 간단한 설치 방법입니다. 패키지 레지스트리 없이 GitHub Release의 번들 파일을 바로 설치합니다. 체크섬까지 검증하려면 아래 방법을 사용하세요.
+
+```bash
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
 if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi

--- a/README-pt_BR.md
+++ b/README-pt_BR.md
@@ -15,6 +15,13 @@
 
 ### Executar
 ```bash
+bun add -g https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+gopeak
+```
+
+Este é o caminho de instalação mais simples. O bundle é instalado diretamente do GitHub Release, sem registro de pacotes. Para verificar também o checksum, use:
+
+```bash
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
 if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi

--- a/README-zh.md
+++ b/README-zh.md
@@ -15,6 +15,13 @@
 
 ### 运行
 ```bash
+bun add -g https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+gopeak
+```
+
+这是最简单的安装方式：无需软件包注册表，直接从 GitHub Release 安装已打包的运行时。如需同时验证校验和，请使用：
+
+```bash
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
 if command -v sha256sum >/dev/null 2>&1; then sha256sum -c gopeak-2.3.9.tgz.sha256; else shasum -a 256 -c gopeak-2.3.9.tgz.sha256; fi

--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ It is designed for trusted Godot 4 workflows: small default tool surface, setup-
 ### 1) Install GoPeak
 
 ```bash
+bun add -g https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
+```
+
+That is the quickest installation path. It installs the bundled runtime directly from GitHub Releases without npm. For a checksum-verified installation, use:
+
+```bash
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz
 curl -fLO https://github.com/HaD0Yun/Doyunha-Gopeak/releases/download/v2.3.9/gopeak-2.3.9.tgz.sha256
 if command -v sha256sum >/dev/null 2>&1; then
@@ -41,7 +47,7 @@ fi
 bun add -g "$PWD/gopeak-2.3.9.tgz"
 ```
 
-This verifies the downloaded release before Bun installs it globally. The absolute tarball path avoids a relative-path bug in Bun 1.3.3. The checksum command works on Linux (`sha256sum`) and macOS (`shasum`). To use the supported installer instead, download or clone the repository and run it locally—do not pipe a remote script into a shell:
+The verified path checks the downloaded release before Bun installs it globally. The absolute tarball path avoids a relative-path bug in Bun 1.3.3. The checksum command works on Linux (`sha256sum`) and macOS (`shasum`). To use the supported installer instead, download or clone the repository and run it locally—do not pipe a remote script into a shell:
 
 ```bash
 git clone https://github.com/HaD0Yun/Doyunha-Gopeak.git


### PR DESCRIPTION
## Summary
- make the direct GitHub Release tarball the primary one-line Bun install
- keep checksum verification as the hardened alternative
- update all localized READMEs

## Verification
- docs and metadata policy tests pass
- direct public URL install succeeds in a clean Bun home
- installed CLI reports gopeak v2.3.9